### PR TITLE
feat: allow disabling dns conntrack zone split

### DIFF
--- a/iptables/builder/builder.go
+++ b/iptables/builder/builder.go
@@ -13,7 +13,7 @@ type IPTables struct {
 	nat *table.NatTable
 }
 
-func NewIPTables(raw *table.RawTable, nat *table.NatTable) *IPTables {
+func newIPTables(raw *table.RawTable, nat *table.NatTable) *IPTables {
 	return &IPTables{
 		raw: raw,
 		nat: nat,
@@ -40,13 +40,13 @@ func (t *IPTables) Build(verbose bool) string {
 	return strings.Join(tables, "\n")
 }
 
-func Build(config *config.Config) (string, error) {
+func BuildIPTables(config *config.Config) (string, error) {
 	loopbackIface, err := getLoopback()
 	if err != nil {
 		return "", fmt.Errorf("cannot obtain loopback interface: %s", err)
 	}
 
-	return NewIPTables(
+	return newIPTables(
 		buildRawTable(config),
 		buildNatTable(config, loopbackIface.Name),
 	).Build(config.Verbose), nil

--- a/iptables/builder/builder_nat.go
+++ b/iptables/builder/builder_nat.go
@@ -32,7 +32,7 @@ func buildMeshOutbound(cfg *config.Config, loopback string) *Chain {
 	outboundChainName := cfg.Redirect.Outbound.Chain.GetFullName()
 	outboundRedirectChainName := cfg.Redirect.Outbound.RedirectChain.GetFullName()
 	excludePorts := cfg.Redirect.Outbound.ExcludePorts
-	shouldRedirectDNS := cfg.Redirect.DNS.Enabled
+	shouldRedirectDNS := func() bool { return cfg.Redirect.DNS.Enabled }
 	dnsRedirectPort := cfg.Redirect.DNS.Port
 	uid := cfg.Owner.UID
 	gid := cfg.Owner.GID
@@ -133,7 +133,7 @@ func buildNatTable(cfg *config.Config, loopback string) *table.NatTable {
 	dnsRedirectPort := cfg.Redirect.DNS.Port
 	uid := cfg.Owner.UID
 	gid := cfg.Owner.GID
-	shouldRedirectDNS := cfg.Redirect.DNS.Enabled
+	shouldRedirectDNS := func() bool { return cfg.Redirect.DNS.Enabled }
 
 	nat := table.Nat()
 

--- a/iptables/builder/builder_raw.go
+++ b/iptables/builder/builder_raw.go
@@ -10,7 +10,7 @@ import (
 func buildRawTable(cfg *config.Config) *table.RawTable {
 	raw := table.Raw()
 
-	if cfg.Redirect.DNS.Enabled() {
+	if cfg.Redirect.DNS.Enabled && cfg.Redirect.DNS.ConntrackZoneSplit {
 		raw.Prerouting().
 			Append(
 				Protocol(Udp(DestinationPort(DNSPort))),

--- a/iptables/config/config.go
+++ b/iptables/config/config.go
@@ -14,12 +14,9 @@ type TrafficFlow struct {
 }
 
 type DNS struct {
-	enabled bool
-	Port    uint16
-}
-
-func (r *DNS) Enabled() bool {
-	return r.enabled
+	Enabled            bool
+	Port               uint16
+	ConntrackZoneSplit bool
 }
 
 type Redirect struct {
@@ -76,7 +73,7 @@ func DefaultConfig() *Config {
 				RedirectChain: &Chain{Name: "MESH_OUTBOUND_REDIRECT"},
 				ExcludePorts:  []uint16{},
 			},
-			DNS: &DNS{Port: 15053, enabled: false},
+			DNS: &DNS{Port: 15053, Enabled: false, ConntrackZoneSplit: true},
 		},
 		Verbose: true,
 	}


### PR DESCRIPTION
As we have to disable dns conntrack zone splitting for the e2e tests in kuma, this change allows us to disable it via config
