### PR TITLE
feat: add option to drop invalid packets

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -27,7 +27,6 @@ github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
-github.com/onsi/ginkgo v1.16.4 h1:29JGrr5oVBm5ulCWet69zQkzWipVXIol6ygQUe/EzNc=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
 github.com/onsi/ginkgo/v2 v2.1.3 h1:e/3Cwtogj0HA+25nMP1jCMDIf8RtRYbGwGGuBIFztkc=
 github.com/onsi/ginkgo/v2 v2.1.3/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=
@@ -74,11 +73,9 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e h1:fLOSk5Q00efkSvAm+4xcoXD+RRmLmmulPn5I3Y9F2EM=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
-golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/iptables/builder/builder.go
+++ b/iptables/builder/builder.go
@@ -14,14 +14,20 @@ import (
 )
 
 type IPTables struct {
-	raw *table.RawTable
-	nat *table.NatTable
+	raw    *table.RawTable
+	nat    *table.NatTable
+	mangle *table.MangleTable
 }
 
-func newIPTables(raw *table.RawTable, nat *table.NatTable) *IPTables {
+func newIPTables(
+	raw *table.RawTable,
+	nat *table.NatTable,
+	mangle *table.MangleTable,
+) *IPTables {
 	return &IPTables{
-		raw: raw,
-		nat: nat,
+		raw:    raw,
+		nat:    nat,
+		mangle: mangle,
 	}
 }
 
@@ -36,6 +42,11 @@ func (t *IPTables) Build(verbose bool) string {
 	nat := t.nat.Build(verbose)
 	if nat != "" {
 		tables = append(tables, nat)
+	}
+
+	mangle := t.mangle.Build(verbose)
+	if mangle != "" {
+		tables = append(tables, mangle)
 	}
 
 	separator := "\n"
@@ -57,6 +68,7 @@ func BuildIPTables(cfg config.Config) (string, error) {
 	return newIPTables(
 		buildRawTable(cfg),
 		buildNatTable(cfg, loopbackIface.Name),
+		buildMangleTable(cfg),
 	).Build(cfg.Verbose), nil
 }
 

--- a/iptables/builder/builder_mangle.go
+++ b/iptables/builder/builder_mangle.go
@@ -1,0 +1,20 @@
+package builder
+
+import (
+	"github.com/kumahq/kuma-net/iptables/config"
+	. "github.com/kumahq/kuma-net/iptables/parameters"
+	. "github.com/kumahq/kuma-net/iptables/parameters/match/conntrack"
+	"github.com/kumahq/kuma-net/iptables/table"
+)
+
+func buildMangleTable(cfg config.Config) *table.MangleTable {
+	mangle := table.Mangle()
+
+	mangle.Prerouting().
+		AppendIf(cfg.ShouldDropInvalidPackets,
+			Match(Conntrack(Ctstate(INVALID))),
+			Jump(Drop()),
+		)
+
+	return mangle
+}

--- a/iptables/config/config.go
+++ b/iptables/config/config.go
@@ -43,12 +43,22 @@ func (c Chain) GetFullName(prefix string) string {
 type Config struct {
 	Owner    Owner
 	Redirect Redirect
+	// DropInvalidPackets when set will enable configuration which should drop
+	// packets in invalid states
+	DropInvalidPackets bool
 	// RuntimeOutput is the place where Any debugging, runtime information
 	// will be placed (os.Stdout by default)
 	RuntimeOutput io.Writer
 	// Verbose when set will generate iptables configuration with longer
 	// argument/flag names, additional comments etc.
 	Verbose bool
+}
+
+// ShouldDropInvalidPackets is just a convenience function which can be used in
+// iptables conditional command generations instead of inlining anonymous functions
+// i.e. AppendIf(ShouldDropInvalidPackets(), Match(...), Jump(Drop()))
+func (c Config) ShouldDropInvalidPackets() bool {
+	return c.DropInvalidPackets
 }
 
 func defaultConfig() Config {
@@ -133,6 +143,9 @@ func MergeConfigWithDefaults(cfg Config) Config {
 	if cfg.Redirect.DNS.Port != 0 {
 		result.Redirect.DNS.Port = cfg.Redirect.DNS.Port
 	}
+
+	// .DropInvalidPackets
+	result.DropInvalidPackets = cfg.DropInvalidPackets
 
 	// .RuntimeOutput
 	if cfg.RuntimeOutput != nil {

--- a/iptables/parameters/jump.go
+++ b/iptables/parameters/jump.go
@@ -40,3 +40,7 @@ func ToPort(port uint16) *JumpParameter {
 func Return() *JumpParameter {
 	return &JumpParameter{parameters: []string{"RETURN"}}
 }
+
+func Drop() *JumpParameter {
+	return &JumpParameter{parameters: []string{"DROP"}}
+}

--- a/iptables/parameters/match/conntrack/conntrack.go
+++ b/iptables/parameters/match/conntrack/conntrack.go
@@ -1,0 +1,28 @@
+package conntrack
+
+type State string
+
+const (
+	// INVALID state means the packet is associated with no known connection
+	INVALID State = "INVALID"
+	// NEW state means the packet has started a new connection or otherwise
+	// associated with a connection which has not seen packets in both
+	// directions
+	NEW State = "NEW"
+	// ESTABLISHED state means the packet is associated with a connection which
+	// has seen packets in both directions
+	ESTABLISHED State = "ESTABLISHED"
+	// RELATED state means the packet is starting a new connection, but
+	// is associated with an existing connection, such as an FTP data transfer
+	// or an ICMP error
+	RELATED State = "RELATED"
+	// UNTRACKED state means the packet is not tracked at all, which happens
+	// if you explicitly untrack it by using -j CT --notrack in the raw table
+	UNTRACKED State = "UNTRACKED"
+	// SNAT state is a virtual state, matching if the original source address
+	// differs from the reply destination
+	SNAT State = "SNAT"
+	// DNAT is a virtual state, matching if the original destination differs
+	// from the reply source.
+	DNAT State = "DNAT"
+)

--- a/iptables/parameters/match_conntrack.go
+++ b/iptables/parameters/match_conntrack.go
@@ -1,0 +1,70 @@
+package parameters
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/kumahq/kuma-net/iptables/parameters/match/conntrack"
+)
+
+// Conntrack
+//       This module, when combined with connection tracking, allows access
+//       to the connection tracking state for this packet/connection.
+//
+//       [!]  --ctstate statelist
+//              statelist is a comma separated list of the connection states to match.
+//              Possible states are listed in ./parameters/match/conntrack
+//
+// ref. iptables-extensions(8) > conntrack
+
+type ConntrackParameter struct {
+	flag     string
+	values   []string
+	negative bool
+}
+
+func (p *ConntrackParameter) Negate() ParameterBuilder {
+	p.negative = !p.negative
+
+	return p
+}
+
+func (p *ConntrackParameter) Build(bool) string {
+	value := strings.Join(p.values, ",")
+
+	if p.negative {
+		return fmt.Sprintf("! %s %s", p.flag, value)
+	}
+
+	return fmt.Sprintf("%s %s", p.flag, value)
+}
+
+// Ctstate expects at least one state is necessary, so that's the reason for split
+// of parameters
+func Ctstate(state conntrack.State, states ...conntrack.State) *ConntrackParameter {
+	values := []string{string(state)}
+
+	for _, s := range states {
+		values = append(values, string(s))
+	}
+
+	return &ConntrackParameter{
+		flag:     "--ctstate",
+		values:   values,
+		negative: false,
+	}
+}
+
+// Conntrack when combined with connection tracking, allows access to the connection tracking state for this packet/connection.
+func Conntrack(conntrackParameters ...*ConntrackParameter) *MatchParameter {
+	var parameters []ParameterBuilder
+
+	for _, parameter := range conntrackParameters {
+		parameters = append(parameters, parameter)
+	}
+
+	return &MatchParameter{
+		name:       "conntrack",
+		parameters: parameters,
+	}
+}

--- a/iptables/parameters/match_conntrack_test.go
+++ b/iptables/parameters/match_conntrack_test.go
@@ -1,0 +1,209 @@
+package parameters_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	. "github.com/kumahq/kuma-net/iptables/parameters"
+	. "github.com/kumahq/kuma-net/iptables/parameters/match/conntrack"
+)
+
+var _ = Describe("ConntrackParameter", func() {
+	Describe("Ctstate", func() {
+		DescribeTable("should build valid ctstate parameter with the combined, "+
+			"provided ...State",
+			func(states []State, verbose bool, want string) {
+				// when
+				got := Ctstate(states[0], states[1:]...).Build(verbose)
+
+				// then
+				Expect(got).To(Equal(want))
+			},
+			// INVALID
+			Entry("INVALID state",
+				[]State{INVALID}, false,
+				"--ctstate INVALID",
+			),
+			Entry("INVALID state - verbose",
+				[]State{INVALID}, true,
+				"--ctstate INVALID",
+			),
+			// NEW
+			Entry("NEW state",
+				[]State{NEW}, false,
+				"--ctstate NEW",
+			),
+			Entry("NEW state - verbose",
+				[]State{NEW}, true,
+				"--ctstate NEW",
+			),
+			// ESTABLISHED
+			Entry("ESTABLISHED state",
+				[]State{ESTABLISHED}, false,
+				"--ctstate ESTABLISHED",
+			),
+			Entry("ESTABLISHED state - verbose",
+				[]State{ESTABLISHED}, true,
+				"--ctstate ESTABLISHED",
+			),
+			// RELATED
+			Entry("RELATED state",
+				[]State{RELATED}, false,
+				"--ctstate RELATED",
+			),
+			Entry("RELATED state - verbose",
+				[]State{RELATED}, true,
+				"--ctstate RELATED",
+			),
+			// UNTRACKED
+			Entry("UNTRACKED state",
+				[]State{UNTRACKED}, false,
+				"--ctstate UNTRACKED",
+			),
+			Entry("UNTRACKED state - verbose",
+				[]State{UNTRACKED}, true,
+				"--ctstate UNTRACKED",
+			),
+			// SNAT
+			Entry("SNAT state",
+				[]State{SNAT}, false,
+				"--ctstate SNAT",
+			),
+			Entry("SNAT state - verbose",
+				[]State{SNAT}, true,
+				"--ctstate SNAT",
+			),
+			// DNAT
+			Entry("DNAT state",
+				[]State{DNAT}, false,
+				"--ctstate DNAT",
+			),
+			Entry("DNAT state - verbose",
+				[]State{DNAT}, true,
+				"--ctstate DNAT",
+			),
+			// Multiple states
+			Entry("Multiple states",
+				[]State{INVALID, NEW, ESTABLISHED, RELATED, UNTRACKED, SNAT, DNAT}, false,
+				"--ctstate INVALID,NEW,ESTABLISHED,RELATED,UNTRACKED,SNAT,DNAT",
+			),
+			Entry("Multiple states - verbose",
+				[]State{INVALID, NEW, ESTABLISHED, RELATED, UNTRACKED, SNAT, DNAT}, true,
+				"--ctstate INVALID,NEW,ESTABLISHED,RELATED,UNTRACKED,SNAT,DNAT",
+			),
+		)
+
+		DescribeTable("should build valid ctstate parameter with the combined, "+
+			"provided ...State when negated",
+			func(states []State, verbose bool, want string) {
+				// when
+				got := Ctstate(states[0], states[1:]...).Negate().Build(verbose)
+
+				// then
+				Expect(got).To(Equal(want))
+			},
+			// INVALID
+			Entry("INVALID state",
+				[]State{INVALID}, false,
+				"! --ctstate INVALID",
+			),
+			Entry("INVALID state - verbose",
+				[]State{INVALID}, true,
+				"! --ctstate INVALID",
+			),
+			// NEW
+			Entry("NEW state",
+				[]State{NEW}, false,
+				"! --ctstate NEW",
+			),
+			Entry("NEW state - verbose",
+				[]State{NEW}, true,
+				"! --ctstate NEW",
+			),
+			// ESTABLISHED
+			Entry("ESTABLISHED state",
+				[]State{ESTABLISHED}, false,
+				"! --ctstate ESTABLISHED",
+			),
+			Entry("ESTABLISHED state - verbose",
+				[]State{ESTABLISHED}, true,
+				"! --ctstate ESTABLISHED",
+			),
+			// RELATED
+			Entry("RELATED state",
+				[]State{RELATED}, false,
+				"! --ctstate RELATED",
+			),
+			Entry("RELATED state - verbose",
+				[]State{RELATED}, true,
+				"! --ctstate RELATED",
+			),
+			// UNTRACKED
+			Entry("UNTRACKED state",
+				[]State{UNTRACKED}, false,
+				"! --ctstate UNTRACKED",
+			),
+			Entry("UNTRACKED state - verbose",
+				[]State{UNTRACKED}, true,
+				"! --ctstate UNTRACKED",
+			),
+			// SNAT
+			Entry("SNAT state",
+				[]State{SNAT}, false,
+				"! --ctstate SNAT",
+			),
+			Entry("SNAT state - verbose",
+				[]State{SNAT}, true,
+				"! --ctstate SNAT",
+			),
+			// DNAT
+			Entry("DNAT state",
+				[]State{DNAT}, false,
+				"! --ctstate DNAT",
+			),
+			Entry("DNAT state - verbose",
+				[]State{DNAT}, true,
+				"! --ctstate DNAT",
+			),
+			// Multiple states
+			Entry("Multiple states",
+				[]State{INVALID, NEW, ESTABLISHED, RELATED, UNTRACKED, SNAT, DNAT}, false,
+				"! --ctstate INVALID,NEW,ESTABLISHED,RELATED,UNTRACKED,SNAT,DNAT",
+			),
+			Entry("Multiple states - verbose",
+				[]State{INVALID, NEW, ESTABLISHED, RELATED, UNTRACKED, SNAT, DNAT}, true,
+				"! --ctstate INVALID,NEW,ESTABLISHED,RELATED,UNTRACKED,SNAT,DNAT",
+			),
+		)
+
+		DescribeTable("Conntrack",
+			func(parameters []*ConntrackParameter, verbose bool, want string) {
+				// when
+				got := Conntrack(parameters...).Build(verbose)
+
+				// then
+				Expect(got).To(Equal(want))
+			},
+			Entry("no parameters",
+				nil, false,
+				"conntrack",
+			),
+			Entry("no parameters - verbose",
+				nil, true,
+				"conntrack",
+			),
+			Entry("1 parameter (Ctstate with all possible states)",
+				[]*ConntrackParameter{Ctstate(
+					INVALID, NEW, ESTABLISHED, RELATED, UNTRACKED, SNAT, DNAT,
+				)}, false,
+				"conntrack --ctstate INVALID,NEW,ESTABLISHED,RELATED,UNTRACKED,SNAT,DNAT",
+			),
+			Entry("1 parameter (Ctstate with all possible states) - verbose",
+				[]*ConntrackParameter{Ctstate(
+					INVALID, NEW, ESTABLISHED, RELATED, UNTRACKED, SNAT, DNAT,
+				)}, true,
+				"conntrack --ctstate INVALID,NEW,ESTABLISHED,RELATED,UNTRACKED,SNAT,DNAT",
+			),
+		)
+	})
+})

--- a/iptables/table/table_mangle.go
+++ b/iptables/table/table_mangle.go
@@ -1,0 +1,58 @@
+package table
+
+import (
+	"github.com/kumahq/kuma-net/iptables/chain"
+)
+
+type MangleTable struct {
+	prerouting  *chain.Chain
+	input       *chain.Chain
+	forward     *chain.Chain
+	output      *chain.Chain
+	postrouting *chain.Chain
+}
+
+func (t *MangleTable) Prerouting() *chain.Chain {
+	return t.prerouting
+}
+
+func (t *MangleTable) Input() *chain.Chain {
+	return t.input
+}
+
+func (t *MangleTable) Forward() *chain.Chain {
+	return t.forward
+}
+
+func (t *MangleTable) Output() *chain.Chain {
+	return t.output
+}
+
+func (t *MangleTable) Postrouting() *chain.Chain {
+	return t.postrouting
+}
+
+func (t *MangleTable) Build(verbose bool) string {
+	table := &TableBuilder{
+		name: "mangle",
+		chains: []*chain.Chain{
+			t.prerouting,
+			t.input,
+			t.forward,
+			t.output,
+			t.postrouting,
+		},
+	}
+
+	return table.Build(verbose)
+}
+
+func Mangle() *MangleTable {
+	return &MangleTable{
+		prerouting:  chain.NewChain("PREROUTING"),
+		input:       chain.NewChain("INPUT"),
+		forward:     chain.NewChain("FORWARD"),
+		output:      chain.NewChain("OUTPUT"),
+		postrouting: chain.NewChain("POSTROUTING"),
+	}
+}


### PR DESCRIPTION
Sometimes (especially in high traffic scenarios) it is possible
that tcp connections would receive packets in invalid state, and
we would like the connection to stay alive and just to drop
this packet.

As to introduce blackbox test for this scenario we would have to:
- manually construct tcp packets to carry out three way tcp
  handshake
- trick kernel (who woundn't know about our TCP connection and
  wound RST the connection immidiately after SYN) to let our
  "forged" connection to be
- make and send some invalid packets, in scenario without this flag
  (connection should be closed) and with the flag enabled
  (connection should stay alive and the packets should be DROPped)
which involves a lot of effort and time, I decided to potentially
do it in following up tasks

Closes: https://github.com/kumahq/kuma-net/issues/21
