### PR TITLE
fix: destination parameter had wrong strings

### DIFF
--- a/iptables/parameters/destination.go
+++ b/iptables/parameters/destination.go
@@ -14,8 +14,8 @@ func (p *DestinationParameter) Negate() ParameterBuilder {
 
 func destination(address string, negative bool) *Parameter {
 	return &Parameter{
-		long:       "--source",
-		short:      "-s",
+		long:       "--destination",
+		short:      "-d",
 		parameters: []ParameterBuilder{&DestinationParameter{address: address}},
 		negate:     negateSelf,
 		negative:   negative,

--- a/iptables/parameters/destination_test.go
+++ b/iptables/parameters/destination_test.go
@@ -1,0 +1,87 @@
+package parameters_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	. "github.com/kumahq/kuma-net/iptables/parameters"
+)
+
+var _ = Describe("DestinationParameter", func() {
+	Describe("Destination", func() {
+		DescribeTable("should build valid destination parameter with, provided address",
+			func(address, want, wantVerbose string) {
+				// when
+				got := Destination(address)
+
+				// then
+				Expect(got.Build(false)).To(Equal(want))
+				Expect(got.Build(true)).To(Equal(wantVerbose))
+			},
+			Entry("IPv4 IP address", "254.254.254.254",
+				"-d 254.254.254.254",
+				"--destination 254.254.254.254",
+			),
+			Entry("IPv4 IP address with CIDR mask", "127.0.0.1/32",
+				"-d 127.0.0.1/32",
+				"--destination 127.0.0.1/32",
+			),
+			Entry("IPv6 IP address", "::1",
+				"-d ::1",
+				"--destination ::1",
+			),
+			Entry("IPv6 IP address with CIDR mask", "f675:e763:3d02:e43c:4734:c8db:481e:295a/128",
+				"-d f675:e763:3d02:e43c:4734:c8db:481e:295a/128",
+				"--destination f675:e763:3d02:e43c:4734:c8db:481e:295a/128",
+			),
+		)
+
+		DescribeTable("should build valid negated destination parameter with, provided address, "+
+			"when negated",
+			func(address, want, wantVerbose string) {
+				// when
+				got := Destination(address).Negate()
+
+				// then
+				Expect(got.Build(false)).To(Equal(want))
+				Expect(got.Build(true)).To(Equal(wantVerbose))
+			},
+			Entry("IPv4 IP address", "254.254.254.254",
+				"! -d 254.254.254.254",
+				"! --destination 254.254.254.254",
+			),
+			Entry("IPv4 IP address with CIDR mask", "127.0.0.1/32",
+				"! -d 127.0.0.1/32",
+				"! --destination 127.0.0.1/32",
+			),
+			Entry("IPv6 IP address", "::1",
+				"! -d ::1",
+				"! --destination ::1",
+			),
+			Entry("IPv6 IP address with CIDR mask", "f675:e763:3d02:e43c:4734:c8db:481e:295a/128",
+				"! -d f675:e763:3d02:e43c:4734:c8db:481e:295a/128",
+				"! --destination f675:e763:3d02:e43c:4734:c8db:481e:295a/128",
+			),
+		)
+	})
+
+	Describe("NotDestination", func() {
+		DescribeTable("should return the result of Destination(...).Negate()",
+			func(address string) {
+				// given
+				want := Destination(address).Negate()
+
+				// when
+				got := NotDestination(address)
+
+				// then
+				Expect(got.Build(false)).To(BeEquivalentTo(want.Build(false)))
+				Expect(got.Build(true)).To(BeEquivalentTo(want.Build(true)))
+			},
+			Entry("IPv4 IP address", "254.254.254.254"),
+			Entry("IPv4 IP address with CIDR mask", "127.0.0.1/32"),
+			Entry("IPv6 IP address", "::1"),
+			Entry("IPv6 IP address with CIDR mask", "f675:e763:3d02:e43c:4734:c8db:481e:295a/128"),
+		)
+	})
+})

--- a/iptables/parameters/destination_test.go
+++ b/iptables/parameters/destination_test.go
@@ -9,60 +9,71 @@ import (
 
 var _ = Describe("DestinationParameter", func() {
 	Describe("Destination", func() {
-		DescribeTable("should build valid destination parameter with, provided address",
-			func(address, want, wantVerbose string) {
-				// when
-				got := Destination(address)
+		Describe("should build valid destination parameter with, provided address", func() {
+			DescribeTable("when not negated",
+				func(address, want, wantVerbose string) {
+					// when
+					got := Destination(address).Build(false)
 
-				// then
-				Expect(got.Build(false)).To(Equal(want))
-				Expect(got.Build(true)).To(Equal(wantVerbose))
-			},
-			Entry("IPv4 IP address", "254.254.254.254",
-				"-d 254.254.254.254",
-				"--destination 254.254.254.254",
-			),
-			Entry("IPv4 IP address with CIDR mask", "127.0.0.1/32",
-				"-d 127.0.0.1/32",
-				"--destination 127.0.0.1/32",
-			),
-			Entry("IPv6 IP address", "::1",
-				"-d ::1",
-				"--destination ::1",
-			),
-			Entry("IPv6 IP address with CIDR mask", "f675:e763:3d02:e43c:4734:c8db:481e:295a/128",
-				"-d f675:e763:3d02:e43c:4734:c8db:481e:295a/128",
-				"--destination f675:e763:3d02:e43c:4734:c8db:481e:295a/128",
-			),
-		)
+					// then
+					Expect(got).To(Equal(want))
 
-		DescribeTable("should build valid negated destination parameter with, provided address, "+
-			"when negated",
-			func(address, want, wantVerbose string) {
-				// when
-				got := Destination(address).Negate()
+					// and, when (verbose)
+					got = Destination(address).Build(true)
 
-				// then
-				Expect(got.Build(false)).To(Equal(want))
-				Expect(got.Build(true)).To(Equal(wantVerbose))
-			},
-			Entry("IPv4 IP address", "254.254.254.254",
-				"! -d 254.254.254.254",
-				"! --destination 254.254.254.254",
-			),
-			Entry("IPv4 IP address with CIDR mask", "127.0.0.1/32",
-				"! -d 127.0.0.1/32",
-				"! --destination 127.0.0.1/32",
-			),
-			Entry("IPv6 IP address", "::1",
-				"! -d ::1",
-				"! --destination ::1",
-			),
-			Entry("IPv6 IP address with CIDR mask", "f675:e763:3d02:e43c:4734:c8db:481e:295a/128",
-				"! -d f675:e763:3d02:e43c:4734:c8db:481e:295a/128",
-				"! --destination f675:e763:3d02:e43c:4734:c8db:481e:295a/128",
-			),
-		)
+					// then
+					Expect(got).To(Equal(wantVerbose))
+				},
+				Entry("IPv4 IP address", "254.254.254.254",
+					"-d 254.254.254.254",
+					"--destination 254.254.254.254",
+				),
+				Entry("IPv4 IP address with CIDR mask", "127.0.0.1/32",
+					"-d 127.0.0.1/32",
+					"--destination 127.0.0.1/32",
+				),
+				Entry("IPv6 IP address", "::1",
+					"-d ::1",
+					"--destination ::1",
+				),
+				Entry("IPv6 IP address with CIDR mask", "::1/128",
+					"-d ::1/128",
+					"--destination ::1/128",
+				),
+			)
+
+			DescribeTable("when negated",
+				func(address, want, wantVerbose string) {
+					// when
+					got := Destination(address).Negate().Build(false)
+
+					// then
+					Expect(got).To(Equal(want))
+
+					// and, when (verbose)
+					got = Destination(address).Negate().Build(true)
+
+					// then
+					Expect(got).To(Equal(wantVerbose))
+				},
+				Entry("IPv4 IP address", "254.254.254.254",
+					"! -d 254.254.254.254",
+					"! --destination 254.254.254.254",
+				),
+				Entry("IPv4 IP address with CIDR mask", "127.0.0.1/32",
+					"! -d 127.0.0.1/32",
+					"! --destination 127.0.0.1/32",
+				),
+				Entry("IPv6 IP address", "::1",
+					"! -d ::1",
+					"! --destination ::1",
+				),
+				Entry("IPv6 IP address with CIDR mask", "::1/128",
+					"! -d ::1/128",
+					"! --destination ::1/128",
+				),
+			)
+		})
 	})
 
 	Describe("NotDestination", func() {
@@ -72,16 +83,21 @@ var _ = Describe("DestinationParameter", func() {
 				want := Destination(address).Negate()
 
 				// when
-				got := NotDestination(address)
+				got := NotDestination(address).Build(false)
 
 				// then
-				Expect(got.Build(false)).To(BeEquivalentTo(want.Build(false)))
-				Expect(got.Build(true)).To(BeEquivalentTo(want.Build(true)))
+				Expect(got).To(BeEquivalentTo(want.Build(false)))
+
+				// and, when (verbose)
+				got = NotDestination(address).Build(true)
+
+				// then
+				Expect(got).To(BeEquivalentTo(want.Build(true)))
 			},
 			Entry("IPv4 IP address", "254.254.254.254"),
 			Entry("IPv4 IP address with CIDR mask", "127.0.0.1/32"),
 			Entry("IPv6 IP address", "::1"),
-			Entry("IPv6 IP address with CIDR mask", "f675:e763:3d02:e43c:4734:c8db:481e:295a/128"),
+			Entry("IPv6 IP address with CIDR mask", "::1/128"),
 		)
 	})
 })


### PR DESCRIPTION
Changed flags of destination parameter from `-s` and `--source`
to `-d` and `--destination` as well as written unit tests
to make sure, this mistake won't happen again for this parameter

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits): 👍 

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?: 👍 
