### PR TITLE
feat: get rid of GID related iptable rules

### DIFF
--- a/iptables/builder/builder_raw.go
+++ b/iptables/builder/builder_raw.go
@@ -24,16 +24,6 @@ func buildRawTable(cfg config.Config) *table.RawTable {
 			).
 			Append(
 				Protocol(Udp(DestinationPort(DNSPort))),
-				Match(Owner(Gid(cfg.Owner.GID))),
-				Jump(Ct(Zone("1"))),
-			).
-			Append(
-				Protocol(Udp(SourcePort(cfg.Redirect.DNS.Port))),
-				Match(Owner(Gid(cfg.Owner.GID))),
-				Jump(Ct(Zone("2"))),
-			).
-			Append(
-				Protocol(Udp(DestinationPort(DNSPort))),
 				Jump(Ct(Zone("2"))),
 			)
 

--- a/iptables/config/config.go
+++ b/iptables/config/config.go
@@ -7,7 +7,6 @@ import (
 
 type Owner struct {
 	UID string
-	GID string
 }
 
 // TrafficFlow is a struct for Inbound/Outbound configuration
@@ -58,14 +57,21 @@ type Config struct {
 
 // ShouldDropInvalidPackets is just a convenience function which can be used in
 // iptables conditional command generations instead of inlining anonymous functions
-// i.e. AppendIf(ShouldDropInvalidPackets(), Match(...), Jump(Drop()))
+// i.e. AppendIf(ShouldDropInvalidPackets, Match(...), Jump(Drop()))
 func (c Config) ShouldDropInvalidPackets() bool {
 	return c.DropInvalidPackets
 }
 
+// ShouldRedirectDNS is just a convenience function which can be used in
+// iptables conditional command generations instead of inlining anonymous functions
+// i.e. AppendIf(ShouldRedirectDNS, Match(...), Jump(Drop()))
+func (c Config) ShouldRedirectDNS() bool {
+	return c.Redirect.DNS.Enabled
+}
+
 func defaultConfig() Config {
 	return Config{
-		Owner: Owner{UID: "5678", GID: "5678"},
+		Owner: Owner{UID: "5678"},
 		Redirect: Redirect{
 			NamePrefix: "",
 			Inbound: TrafficFlow{
@@ -95,10 +101,6 @@ func MergeConfigWithDefaults(cfg Config) Config {
 	// .Owner
 	if cfg.Owner.UID != "" {
 		result.Owner.UID = cfg.Owner.UID
-	}
-
-	if cfg.Owner.GID != "" {
-		result.Owner.GID = cfg.Owner.GID
 	}
 
 	// .Redirect


### PR DESCRIPTION
Removing GID related iptable rules which simplifies the whole rules set

+ added one convenience function to the config struct

Closes: https://github.com/kumahq/kuma-net/issues/28

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits): 👍 

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?: 👍 
