### PR TITLE
chore: enable by default dns conntrack zone split

### DIFF
--- a/iptables/config/config.go
+++ b/iptables/config/config.go
@@ -86,7 +86,7 @@ func defaultConfig() Config {
 				RedirectChain: Chain{Name: "MESH_OUTBOUND_REDIRECT"},
 				ExcludePorts:  []uint16{},
 			},
-			DNS: DNS{Port: 15053, Enabled: false, ConntrackZoneSplit: false},
+			DNS: DNS{Port: 15053, Enabled: false, ConntrackZoneSplit: true},
 		},
 		DropInvalidPackets: false,
 		IPv6:               false,


### PR DESCRIPTION
Enable DNS conntrack zone splitting in config by default

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits): 👍 

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?: 👍 
