### PR TITLE
feat: introduce inbound ipv6 redirect port (15010)

### DIFF
--- a/iptables/builder/builder_nat.go
+++ b/iptables/builder/builder_nat.go
@@ -120,7 +120,7 @@ func buildMeshRedirect(cfg config.TrafficFlow, prefix string, ipv6 bool) *Chain 
 	chainName := cfg.RedirectChain.GetFullName(prefix)
 
 	redirectPort := cfg.Port
-	if ipv6 {
+	if ipv6 && cfg.PortIPv6 != 0 {
 		redirectPort = cfg.PortIPv6
 	}
 

--- a/iptables/builder/builder_nat.go
+++ b/iptables/builder/builder_nat.go
@@ -116,7 +116,14 @@ func buildMeshOutbound(cfg config.Config, loopback string, ipv6 bool) *Chain {
 	return meshOutbound
 }
 
-func buildMeshRedirect(chainName string, redirectPort uint16) *Chain {
+func buildMeshRedirect(cfg config.TrafficFlow, prefix string, ipv6 bool) *Chain {
+	chainName := cfg.RedirectChain.GetFullName(prefix)
+
+	redirectPort := cfg.Port
+	if ipv6 {
+		redirectPort = cfg.PortIPv6
+	}
+
 	return NewChain(chainName).
 		Append(
 			Protocol(Tcp()),
@@ -129,9 +136,6 @@ func buildNatTable(cfg config.Config, loopback string, ipv6 bool) *table.NatTabl
 	inboundRedirectChainName := cfg.Redirect.Inbound.RedirectChain.GetFullName(prefix)
 	inboundChainName := cfg.Redirect.Inbound.Chain.GetFullName(prefix)
 	outboundChainName := cfg.Redirect.Outbound.Chain.GetFullName(prefix)
-	outboundRedirectChainName := cfg.Redirect.Outbound.RedirectChain.GetFullName(prefix)
-	inboundRedirectPort := cfg.Redirect.Inbound.Port
-	outboundRedirectPort := cfg.Redirect.Outbound.Port
 	dnsRedirectPort := cfg.Redirect.DNS.Port
 	uid := cfg.Owner.UID
 
@@ -161,13 +165,13 @@ func buildNatTable(cfg config.Config, loopback string, ipv6 bool) *table.NatTabl
 	meshInbound := buildMeshInbound(cfg.Redirect.Inbound, prefix, inboundRedirectChainName)
 
 	// MESH_INBOUND_REDIRECT
-	meshInboundRedirect := buildMeshRedirect(inboundRedirectChainName, inboundRedirectPort)
+	meshInboundRedirect := buildMeshRedirect(cfg.Redirect.Inbound, prefix, ipv6)
 
 	// MESH_OUTBOUND
 	meshOutbound := buildMeshOutbound(cfg, loopback, ipv6)
 
 	// MESH_OUTBOUND_REDIRECT
-	meshOutboundRedirect := buildMeshRedirect(outboundRedirectChainName, outboundRedirectPort)
+	meshOutboundRedirect := buildMeshRedirect(cfg.Redirect.Outbound, prefix, ipv6)
 
 	return nat.
 		WithChain(meshInbound).

--- a/iptables/config/config.go
+++ b/iptables/config/config.go
@@ -12,6 +12,7 @@ type Owner struct {
 // TrafficFlow is a struct for Inbound/Outbound configuration
 type TrafficFlow struct {
 	Port          uint16
+	PortIPv6      uint16
 	Chain         Chain
 	RedirectChain Chain
 	ExcludePorts  []uint16
@@ -76,6 +77,7 @@ func defaultConfig() Config {
 			NamePrefix: "",
 			Inbound: TrafficFlow{
 				Port:          15006,
+				PortIPv6:      15010,
 				Chain:         Chain{Name: "MESH_INBOUND"},
 				RedirectChain: Chain{Name: "MESH_INBOUND_REDIRECT"},
 				ExcludePorts:  []uint16{},
@@ -111,6 +113,10 @@ func MergeConfigWithDefaults(cfg Config) Config {
 	// .Redirect.Inbound
 	if cfg.Redirect.Inbound.Port != 0 {
 		result.Redirect.Inbound.Port = cfg.Redirect.Inbound.Port
+	}
+
+	if cfg.Redirect.Inbound.PortIPv6 != 0 {
+		result.Redirect.Inbound.PortIPv6 = cfg.Redirect.Inbound.PortIPv6
 	}
 
 	if cfg.Redirect.Inbound.Chain.Name != "" {

--- a/test/blackbox_tests/inbound_redirect_test.go
+++ b/test/blackbox_tests/inbound_redirect_test.go
@@ -107,7 +107,7 @@ var _ = Describe("Inbound IPv6 TCP traffic from any ports", func() {
 			tproxyConfig := config.Config{
 				Redirect: config.Redirect{
 					Inbound: config.TrafficFlow{
-						Port: serverPort,
+						PortIPv6: serverPort,
 					},
 				},
 				IPv6:          true,

--- a/test/blackbox_tests/inbound_redirect_test.go
+++ b/test/blackbox_tests/inbound_redirect_test.go
@@ -262,7 +262,7 @@ var _ = Describe("Inbound IPv6 TCP traffic from any ports except excluded ones",
 			tproxyConfig := config.Config{
 				Redirect: config.Redirect{
 					Inbound: config.TrafficFlow{
-						Port:         serverPort,
+						PortIPv6:     serverPort,
 						ExcludePorts: []uint16{excludedPort},
 					},
 				},


### PR DESCRIPTION
As in kuma we are using specific listeners/clusters for IPv6
inbound traffic, this changes allow to specify port to allow this

Closes: https://github.com/kumahq/kuma-net/issues/47

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits): 👍 

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?: 👍 
