### PR TITLE
feat: dns conntrack rules when extension available

### DIFF
--- a/iptables/builder/builder_raw.go
+++ b/iptables/builder/builder_raw.go
@@ -10,7 +10,7 @@ import (
 func buildRawTable(cfg config.Config) *table.RawTable {
 	raw := table.Raw()
 
-	if cfg.Redirect.DNS.Enabled && cfg.Redirect.DNS.ConntrackZoneSplit {
+	if cfg.ShouldConntrackZoneSplit() {
 		raw.Output().
 			Append(
 				Protocol(Udp(DestinationPort(DNSPort))),

--- a/iptables/config/config.go
+++ b/iptables/config/config.go
@@ -84,12 +84,11 @@ func (c Config) ShouldConntrackZoneSplit() bool {
 	// There are situations where conntrack extension is not present (WSL2)
 	// instead of failing the whole iptables application, we can log the warning,
 	// skip conntrack related rules and move forward
-	if output, err := exec.Command("iptables", "-m", "conntrack", "--help").
-		CombinedOutput(); err != nil {
+	if err := exec.Command("iptables", "-m", "conntrack", "--help").Run(); err != nil {
 		_, _ = fmt.Fprintf(c.RuntimeOutput,
 			"[WARNING] error occured when validating if 'conntrack' iptables "+
-				"module is present: \n%s: %s\nRules for DNS conntrack zone "+
-				"splitting won't be applied", output, err,
+				"module is present. Rules for DNS conntrack zone "+
+				"splitting won't be applied: %s\n", err,
 		)
 
 		return false


### PR DESCRIPTION
Added logic to validate if there is `conntrack` iptables extension
available, before applying dns conntrack zone splitting related
rules. If it's not available (WSL2), then print warning and move
forward.

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits): 👍 

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?: 👍 
