### PR TITLE
feat: move firewalld from kuma to kuma-net

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,7 +11,7 @@ env:
   CGO_ENABLED: "0"
 
 jobs:
-  unit-tests-iptables:
+  unit-tests:
     runs-on: ubuntu-latest
 
     steps:
@@ -34,9 +34,13 @@ jobs:
 
     - name: "Run unit tests for iptables engine"
       run: |
-        go test ./iptables/...
+        ginkgo run ./iptables/...
 
-  blackbox-tests-iptables:
+    - name: "Run unit tests for firewalld"
+      run: |
+        ginkgo run ./firewalld/...
+
+  blackbox-tests:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,6 +32,10 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
 
+    - name: "Install dependencies"
+      run: |
+        go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo
+
     - name: "Run unit tests for iptables engine"
       run: |
         ginkgo run ./iptables/...

--- a/firewalld/firewalld.go
+++ b/firewalld/firewalld.go
@@ -1,0 +1,209 @@
+package firewalld
+
+import (
+	"bufio"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// As specified in https://firewalld.org/documentation/man-pages/firewalld.direct.html
+
+const (
+	defaultFirewalldDirectPath = "/etc/firewalld/direct.xml"
+	defaultRulenum             = 3
+)
+
+type IptablesRule struct {
+	Mode          string
+	Chain         string
+	Rulenum       int
+	Specification string
+}
+
+type IptablesTranslator struct {
+	dryRun         bool
+	output         io.Writer
+	directFilePath string
+	ruleParser     *regexp.Regexp
+}
+
+func (t *IptablesTranslator) WithDirectFilePath(filePath string) *IptablesTranslator {
+	t.directFilePath = filePath
+
+	return t
+}
+
+func (t *IptablesTranslator) WithDryRun(dryRun bool) *IptablesTranslator {
+	t.dryRun = dryRun
+
+	return t
+}
+
+func (t *IptablesTranslator) WithOutput(output io.Writer) *IptablesTranslator {
+	t.output = output
+
+	return t
+}
+
+func filterOutEmptyAndCommentLines(lines []string) []string {
+	var result []string
+
+	for _, line := range lines {
+		if line != "" && !strings.HasPrefix(line, "#") {
+			result = append(result, line)
+		}
+	}
+
+	return result
+}
+
+func (t *IptablesTranslator) StoreRules(rawIptables string) (string, error) {
+	direct, err := t.getPersistentDirect()
+	if err != nil {
+		return "", err
+	}
+
+	for table, rawRules := range parseIptablesRawInput(rawIptables) {
+		for _, rawRule := range filterOutEmptyAndCommentLines(rawRules) {
+			rule := t.translateRule(rawRule)
+
+			switch rule.Mode {
+			case "N", "new-chain":
+				direct.AddChain(NewIP4Chain(table, rule.Chain))
+			case "A", "append":
+				direct.AddRule(NewIP4Rule(
+					table,
+					rule.Rulenum,
+					rule.Chain,
+					rule.Specification,
+				))
+			default:
+				return "", fmt.Errorf("unsupported iptables mode [%s]", rule.Mode)
+			}
+		}
+	}
+
+	return t.store(direct)
+}
+
+func (t *IptablesTranslator) translateRule(rule string) IptablesRule {
+	var result IptablesRule
+
+	match := t.ruleParser.FindStringSubmatch(rule)
+
+	for i, name := range t.ruleParser.SubexpNames() {
+		if i != 0 && name != "" {
+			switch name {
+			case "mode":
+				result.Mode = match[i]
+			case "chain":
+				result.Chain = match[i]
+			case "rulenum":
+				rulenum, err := strconv.Atoi(match[i])
+				if err != nil || rulenum == 0 {
+					rulenum = defaultRulenum
+				}
+
+				result.Rulenum = rulenum
+			case "specification":
+				result.Specification = match[i]
+			}
+		}
+	}
+
+	return result
+}
+
+func (t *IptablesTranslator) getPersistentDirect() (*Direct, error) {
+	result := NewDirect()
+
+	if t.dryRun {
+		return result, nil
+	}
+
+	if _, err := os.Stat(t.directFilePath); err != nil {
+		if os.IsPermission(err) {
+			return nil, err
+		}
+
+		if os.IsNotExist(err) {
+			// file does not exist, return an empty line
+			return result, nil
+		}
+	}
+
+	data, err := os.ReadFile(t.directFilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	err = xml.Unmarshal(data, result)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (t *IptablesTranslator) store(direct *Direct) (string, error) {
+	content := "\n\n" + direct.String() + "\n\n"
+
+	if !t.dryRun {
+		// -rw-r--r--.  1 root root  191 Mar 18 07:58 direct.xml
+		if err := os.WriteFile(t.directFilePath, direct.Bytes(), 0644); err != nil {
+			return direct.String(), err
+		}
+
+		content += "iptables saved with firewalld" + "\n\n"
+	}
+
+	_, _ = t.output.Write([]byte(content))
+
+	return direct.String(), nil
+}
+
+func parseIptablesRawInput(input string) map[string][]string {
+	tableParser := regexp.MustCompile(`\* (?P<table>\w*)`)
+	scanner := bufio.NewScanner(strings.NewReader(input))
+	rules := map[string][]string{}
+	table := ""
+
+	scanner.Split(bufio.ScanLines)
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if strings.Contains(line, "COMMIT") {
+			table = ""
+
+			continue
+		}
+
+		if matches := tableParser.FindStringSubmatch(line); len(matches) > 1 {
+			table = matches[tableParser.SubexpIndex("table")]
+
+			continue
+		}
+
+		// filter out empty and comment lines
+		if table != "" && line != "" && !strings.HasPrefix(line, "#") {
+			rules[table] = append(rules[table], line)
+		}
+	}
+
+	return rules
+}
+
+func NewIptablesTranslator() *IptablesTranslator {
+	return &IptablesTranslator{
+		output:         io.Discard,
+		directFilePath: defaultFirewalldDirectPath,
+		ruleParser: regexp.MustCompile(
+			`--?(?P<mode>[A-Za-z-]+)\s*(?P<chain>\w*)\s*(?P<rulenum>\d+)?\s*(?P<specification>.*)?`,
+		),
+	}
+}

--- a/firewalld/firewalld_suite_test.go
+++ b/firewalld/firewalld_suite_test.go
@@ -1,0 +1,13 @@
+package firewalld_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func Test(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Firewalld Suite")
+}

--- a/firewalld/firewalld_test.go
+++ b/firewalld/firewalld_test.go
@@ -1,0 +1,41 @@
+package firewalld
+
+import (
+	"os"
+	"path"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	. "github.com/kumahq/kuma-net/test/framework/gomega_matchers"
+)
+
+type testCase struct {
+	inputFile  string
+	goldenFile string
+}
+
+var _ = Describe("firewalld", func() {
+	DescribeTable("check xml generation",
+		func(given testCase) {
+			rules, err := os.ReadFile(path.Join("testdata", given.inputFile))
+			Expect(err).To(Succeed())
+
+			Expect(NewIptablesTranslator().WithDryRun(true).StoreRules(string(rules))).
+				To(MatchGoldenXML("testdata", given.goldenFile))
+		},
+		Entry("should generate xml", testCase{
+			inputFile:  "full_direct.input.txt",
+			goldenFile: "full_direct.golden.xml",
+		}),
+		Entry("should generate xml for verbose rules", testCase{
+			inputFile:  "full_direct_verbose.input.txt",
+			goldenFile: "full_direct_verbose.golden.xml",
+		}),
+		Entry("should generate xml without duplicates", testCase{
+			inputFile:  "no_duplicates_direct.input.txt",
+			goldenFile: "no_duplicates_direct.golden.xml",
+		}),
+	)
+
+})

--- a/firewalld/testdata/full_direct.golden.xml
+++ b/firewalld/testdata/full_direct.golden.xml
@@ -18,8 +18,4 @@
   <rule ipv="ipv4" table="nat" chain="KUMA_MESH_OUTBOUND" priority="3">-j KUMA_MESH_OUTBOUND_REDIRECT</rule>
   <rule ipv="ipv4" table="nat" chain="KUMA_MESH_INBOUND_REDIRECT" priority="3">-p tcp -j REDIRECT --to-ports 15006</rule>
   <rule ipv="ipv4" table="nat" chain="KUMA_MESH_OUTBOUND_REDIRECT" priority="3">-p tcp -j REDIRECT --to-ports 15001</rule>
-  <rule ipv="ipv4" table="raw" chain="PREROUTING" priority="3">-p udp --sport 53 -j CT --zone 1</rule>
-  <rule ipv="ipv4" table="raw" chain="OUTPUT" priority="3">-p udp --dport 53 -m owner --uid-owner 5678 -j CT --zone 1</rule>
-  <rule ipv="ipv4" table="raw" chain="OUTPUT" priority="3">-p udp --sport 15053 -m owner --uid-owner 5678 -j CT --zone 2</rule>
-  <rule ipv="ipv4" table="raw" chain="OUTPUT" priority="3">-p udp --dport 53 -j CT --zone 2</rule>
 </direct>

--- a/firewalld/testdata/full_direct.golden.xml
+++ b/firewalld/testdata/full_direct.golden.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<direct>
+  <chain ipv="ipv4" table="nat" chain="KUMA_MESH_INBOUND"></chain>
+  <chain ipv="ipv4" table="nat" chain="KUMA_MESH_OUTBOUND"></chain>
+  <chain ipv="ipv4" table="nat" chain="KUMA_MESH_INBOUND_REDIRECT"></chain>
+  <chain ipv="ipv4" table="nat" chain="KUMA_MESH_OUTBOUND_REDIRECT"></chain>
+  <rule ipv="ipv4" table="nat" chain="PREROUTING" priority="3">-p tcp -j KUMA_MESH_INBOUND</rule>
+  <rule ipv="ipv4" table="nat" chain="OUTPUT" priority="3">-p udp --dport 53 -m owner --uid-owner 5678 -j RETURN</rule>
+  <rule ipv="ipv4" table="nat" chain="OUTPUT" priority="3">-p udp --dport 53 -j REDIRECT --to-ports 15053</rule>
+  <rule ipv="ipv4" table="nat" chain="OUTPUT" priority="3">-p tcp -j KUMA_MESH_OUTBOUND</rule>
+  <rule ipv="ipv4" table="nat" chain="KUMA_MESH_INBOUND" priority="3">-p tcp -j KUMA_MESH_INBOUND_REDIRECT</rule>
+  <rule ipv="ipv4" table="nat" chain="KUMA_MESH_OUTBOUND" priority="3">-s 127.0.0.6/32 -o lo -j RETURN</rule>
+  <rule ipv="ipv4" table="nat" chain="KUMA_MESH_OUTBOUND" priority="3">-p tcp ! --dport 53 -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT</rule>
+  <rule ipv="ipv4" table="nat" chain="KUMA_MESH_OUTBOUND" priority="3">-p tcp ! --dport 53 -o lo -m owner ! --uid-owner 5678 -j RETURN</rule>
+  <rule ipv="ipv4" table="nat" chain="KUMA_MESH_OUTBOUND" priority="3">-m owner --uid-owner 5678 -j RETURN</rule>
+  <rule ipv="ipv4" table="nat" chain="KUMA_MESH_OUTBOUND" priority="3">-p tcp --dport 53 -j REDIRECT --to-ports 15053</rule>
+  <rule ipv="ipv4" table="nat" chain="KUMA_MESH_OUTBOUND" priority="3">-d 127.0.0.1/32 -j RETURN</rule>
+  <rule ipv="ipv4" table="nat" chain="KUMA_MESH_OUTBOUND" priority="3">-j KUMA_MESH_OUTBOUND_REDIRECT</rule>
+  <rule ipv="ipv4" table="nat" chain="KUMA_MESH_INBOUND_REDIRECT" priority="3">-p tcp -j REDIRECT --to-ports 15006</rule>
+  <rule ipv="ipv4" table="nat" chain="KUMA_MESH_OUTBOUND_REDIRECT" priority="3">-p tcp -j REDIRECT --to-ports 15001</rule>
+  <rule ipv="ipv4" table="raw" chain="PREROUTING" priority="3">-p udp --sport 53 -j CT --zone 1</rule>
+  <rule ipv="ipv4" table="raw" chain="OUTPUT" priority="3">-p udp --dport 53 -m owner --uid-owner 5678 -j CT --zone 1</rule>
+  <rule ipv="ipv4" table="raw" chain="OUTPUT" priority="3">-p udp --sport 15053 -m owner --uid-owner 5678 -j CT --zone 2</rule>
+  <rule ipv="ipv4" table="raw" chain="OUTPUT" priority="3">-p udp --dport 53 -j CT --zone 2</rule>
+</direct>

--- a/firewalld/testdata/full_direct.input.txt
+++ b/firewalld/testdata/full_direct.input.txt
@@ -1,0 +1,26 @@
+* raw
+-A PREROUTING -p udp --sport 53 -j CT --zone 1
+-A OUTPUT -p udp --dport 53 -m owner --uid-owner 5678 -j CT --zone 1
+-A OUTPUT -p udp --sport 15053 -m owner --uid-owner 5678 -j CT --zone 2
+-A OUTPUT -p udp --dport 53 -j CT --zone 2
+COMMIT
+* nat
+-N KUMA_MESH_INBOUND
+-N KUMA_MESH_OUTBOUND
+-N KUMA_MESH_INBOUND_REDIRECT
+-N KUMA_MESH_OUTBOUND_REDIRECT
+-A PREROUTING -p tcp -j KUMA_MESH_INBOUND
+-A OUTPUT -p udp --dport 53 -m owner --uid-owner 5678 -j RETURN
+-A OUTPUT -p udp --dport 53 -j REDIRECT --to-ports 15053
+-A OUTPUT -p tcp -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -j KUMA_MESH_INBOUND_REDIRECT
+-A KUMA_MESH_OUTBOUND -s 127.0.0.6/32 -o lo -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp ! --dport 53 -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 5678 -j KUMA_MESH_INBOUND_REDIRECT
+-A KUMA_MESH_OUTBOUND -p tcp ! --dport 53 -o lo -m owner ! --uid-owner 5678 -j RETURN
+-A KUMA_MESH_OUTBOUND -m owner --uid-owner 5678 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp --dport 53 -j REDIRECT --to-ports 15053
+-A KUMA_MESH_OUTBOUND -d 127.0.0.1/32 -j RETURN
+-A KUMA_MESH_OUTBOUND -j KUMA_MESH_OUTBOUND_REDIRECT
+-A KUMA_MESH_INBOUND_REDIRECT -p tcp -j REDIRECT --to-ports 15006
+-A KUMA_MESH_OUTBOUND_REDIRECT -p tcp -j REDIRECT --to-ports 15001
+COMMIT

--- a/firewalld/testdata/full_direct.input.txt
+++ b/firewalld/testdata/full_direct.input.txt
@@ -1,9 +1,3 @@
-* raw
--A PREROUTING -p udp --sport 53 -j CT --zone 1
--A OUTPUT -p udp --dport 53 -m owner --uid-owner 5678 -j CT --zone 1
--A OUTPUT -p udp --sport 15053 -m owner --uid-owner 5678 -j CT --zone 2
--A OUTPUT -p udp --dport 53 -j CT --zone 2
-COMMIT
 * nat
 -N KUMA_MESH_INBOUND
 -N KUMA_MESH_OUTBOUND

--- a/firewalld/testdata/full_direct_verbose.golden.xml
+++ b/firewalld/testdata/full_direct_verbose.golden.xml
@@ -4,10 +4,6 @@
   <chain ipv="ipv4" table="nat" chain="KUMA_MESH_OUTBOUND"></chain>
   <chain ipv="ipv4" table="nat" chain="KUMA_MESH_INBOUND_REDIRECT"></chain>
   <chain ipv="ipv4" table="nat" chain="KUMA_MESH_OUTBOUND_REDIRECT"></chain>
-  <rule ipv="ipv4" table="raw" chain="PREROUTING" priority="3">--protocol udp --source-port 53 --jump CT --zone 1</rule>
-  <rule ipv="ipv4" table="raw" chain="OUTPUT" priority="3">--protocol udp --destination-port 53 --match owner --uid-owner 5678 --jump CT --zone 1</rule>
-  <rule ipv="ipv4" table="raw" chain="OUTPUT" priority="3">--protocol udp --source-port 15053 --match owner --uid-owner 5678 --jump CT --zone 2</rule>
-  <rule ipv="ipv4" table="raw" chain="OUTPUT" priority="3">--protocol udp --destination-port 53 --jump CT --zone 2</rule>
   <rule ipv="ipv4" table="nat" chain="PREROUTING" priority="3">--protocol tcp --jump KUMA_MESH_INBOUND</rule>
   <rule ipv="ipv4" table="nat" chain="OUTPUT" priority="3">--protocol udp --destination-port 53 --match owner --uid-owner 5678 --jump RETURN</rule>
   <rule ipv="ipv4" table="nat" chain="OUTPUT" priority="3">--protocol udp --destination-port 53 --jump REDIRECT --to-ports 15053</rule>

--- a/firewalld/testdata/full_direct_verbose.golden.xml
+++ b/firewalld/testdata/full_direct_verbose.golden.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<direct>
+  <chain ipv="ipv4" table="nat" chain="KUMA_MESH_INBOUND"></chain>
+  <chain ipv="ipv4" table="nat" chain="KUMA_MESH_OUTBOUND"></chain>
+  <chain ipv="ipv4" table="nat" chain="KUMA_MESH_INBOUND_REDIRECT"></chain>
+  <chain ipv="ipv4" table="nat" chain="KUMA_MESH_OUTBOUND_REDIRECT"></chain>
+  <rule ipv="ipv4" table="raw" chain="PREROUTING" priority="3">--protocol udp --source-port 53 --jump CT --zone 1</rule>
+  <rule ipv="ipv4" table="raw" chain="OUTPUT" priority="3">--protocol udp --destination-port 53 --match owner --uid-owner 5678 --jump CT --zone 1</rule>
+  <rule ipv="ipv4" table="raw" chain="OUTPUT" priority="3">--protocol udp --source-port 15053 --match owner --uid-owner 5678 --jump CT --zone 2</rule>
+  <rule ipv="ipv4" table="raw" chain="OUTPUT" priority="3">--protocol udp --destination-port 53 --jump CT --zone 2</rule>
+  <rule ipv="ipv4" table="nat" chain="PREROUTING" priority="3">--protocol tcp --jump KUMA_MESH_INBOUND</rule>
+  <rule ipv="ipv4" table="nat" chain="OUTPUT" priority="3">--protocol udp --destination-port 53 --match owner --uid-owner 5678 --jump RETURN</rule>
+  <rule ipv="ipv4" table="nat" chain="OUTPUT" priority="3">--protocol udp --destination-port 53 --jump REDIRECT --to-ports 15053</rule>
+  <rule ipv="ipv4" table="nat" chain="OUTPUT" priority="3">--protocol tcp --jump KUMA_MESH_OUTBOUND</rule>
+  <rule ipv="ipv4" table="nat" chain="KUMA_MESH_INBOUND" priority="3">--protocol tcp --jump KUMA_MESH_INBOUND_REDIRECT</rule>
+  <rule ipv="ipv4" table="nat" chain="KUMA_MESH_OUTBOUND" priority="3">--source 127.0.0.6/32 --out-interface lo --jump RETURN</rule>
+  <rule ipv="ipv4" table="nat" chain="KUMA_MESH_OUTBOUND" priority="3">--protocol tcp ! --destination-port 53 --out-interface lo ! --destination 127.0.0.1/32 --match owner --uid-owner 5678 --jump KUMA_MESH_INBOUND_REDIRECT</rule>
+  <rule ipv="ipv4" table="nat" chain="KUMA_MESH_OUTBOUND" priority="3">--protocol tcp ! --destination-port 53 --out-interface lo --match owner ! --uid-owner 5678 --jump RETURN</rule>
+  <rule ipv="ipv4" table="nat" chain="KUMA_MESH_OUTBOUND" priority="3">--match owner --uid-owner 5678 --jump RETURN</rule>
+  <rule ipv="ipv4" table="nat" chain="KUMA_MESH_OUTBOUND" priority="3">--protocol tcp --destination-port 53 --jump REDIRECT --to-ports 15053</rule>
+  <rule ipv="ipv4" table="nat" chain="KUMA_MESH_OUTBOUND" priority="3">--destination 127.0.0.1/32 --jump RETURN</rule>
+  <rule ipv="ipv4" table="nat" chain="KUMA_MESH_OUTBOUND" priority="3">--jump KUMA_MESH_OUTBOUND_REDIRECT</rule>
+  <rule ipv="ipv4" table="nat" chain="KUMA_MESH_INBOUND_REDIRECT" priority="3">--protocol tcp --jump REDIRECT --to-ports 15006</rule>
+  <rule ipv="ipv4" table="nat" chain="KUMA_MESH_OUTBOUND_REDIRECT" priority="3">--protocol tcp --jump REDIRECT --to-ports 15001</rule>
+</direct>

--- a/firewalld/testdata/full_direct_verbose.input.txt
+++ b/firewalld/testdata/full_direct_verbose.input.txt
@@ -1,0 +1,35 @@
+* raw
+
+# Rules:
+--append PREROUTING --protocol udp --source-port 53 --jump CT --zone 1
+--append OUTPUT --protocol udp --destination-port 53 --match owner --uid-owner 5678 --jump CT --zone 1
+--append OUTPUT --protocol udp --source-port 15053 --match owner --uid-owner 5678 --jump CT --zone 2
+--append OUTPUT --protocol udp --destination-port 53 --jump CT --zone 2
+
+COMMIT
+
+* nat
+
+# Custom Chains:
+--new-chain KUMA_MESH_INBOUND
+--new-chain KUMA_MESH_OUTBOUND
+--new-chain KUMA_MESH_INBOUND_REDIRECT
+--new-chain KUMA_MESH_OUTBOUND_REDIRECT
+
+# Rules:
+--append PREROUTING --protocol tcp --jump KUMA_MESH_INBOUND
+--append OUTPUT --protocol udp --destination-port 53 --match owner --uid-owner 5678 --jump RETURN
+--append OUTPUT --protocol udp --destination-port 53 --jump REDIRECT --to-ports 15053
+--append OUTPUT --protocol tcp --jump KUMA_MESH_OUTBOUND
+--append KUMA_MESH_INBOUND --protocol tcp --jump KUMA_MESH_INBOUND_REDIRECT
+--append KUMA_MESH_OUTBOUND --source 127.0.0.6/32 --out-interface lo --jump RETURN
+--append KUMA_MESH_OUTBOUND --protocol tcp ! --destination-port 53 --out-interface lo ! --destination 127.0.0.1/32 --match owner --uid-owner 5678 --jump KUMA_MESH_INBOUND_REDIRECT
+--append KUMA_MESH_OUTBOUND --protocol tcp ! --destination-port 53 --out-interface lo --match owner ! --uid-owner 5678 --jump RETURN
+--append KUMA_MESH_OUTBOUND --match owner --uid-owner 5678 --jump RETURN
+--append KUMA_MESH_OUTBOUND --protocol tcp --destination-port 53 --jump REDIRECT --to-ports 15053
+--append KUMA_MESH_OUTBOUND --destination 127.0.0.1/32 --jump RETURN
+--append KUMA_MESH_OUTBOUND --jump KUMA_MESH_OUTBOUND_REDIRECT
+--append KUMA_MESH_INBOUND_REDIRECT --protocol tcp --jump REDIRECT --to-ports 15006
+--append KUMA_MESH_OUTBOUND_REDIRECT --protocol tcp --jump REDIRECT --to-ports 15001
+
+COMMIT

--- a/firewalld/testdata/full_direct_verbose.input.txt
+++ b/firewalld/testdata/full_direct_verbose.input.txt
@@ -1,13 +1,3 @@
-* raw
-
-# Rules:
---append PREROUTING --protocol udp --source-port 53 --jump CT --zone 1
---append OUTPUT --protocol udp --destination-port 53 --match owner --uid-owner 5678 --jump CT --zone 1
---append OUTPUT --protocol udp --source-port 15053 --match owner --uid-owner 5678 --jump CT --zone 2
---append OUTPUT --protocol udp --destination-port 53 --jump CT --zone 2
-
-COMMIT
-
 * nat
 
 # Custom Chains:

--- a/firewalld/testdata/no_duplicates_direct.golden.xml
+++ b/firewalld/testdata/no_duplicates_direct.golden.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<direct>
+  <chain ipv="ipv4" table="nat" chain="KUMA_INBOUND"></chain>
+  <chain ipv="ipv4" table="nat" chain="KUMA_OUTPUT"></chain>
+  <rule ipv="ipv4" table="raw" chain="PREROUTING" priority="3">-p udp --sport 53 -j CT --zone 1</rule>
+  <rule ipv="ipv4" table="raw" chain="OUTPUT" priority="3">-p udp --dport 53 -m owner --uid-owner 5678 -j CT --zone 1</rule>
+  <rule ipv="ipv4" table="raw" chain="OUTPUT" priority="3">-p udp --sport 15053 -m owner --uid-owner 5678 -j CT --zone 2</rule>
+  <rule ipv="ipv4" table="raw" chain="OUTPUT" priority="3">-p udp --dport 53 -j CT --zone 2</rule>
+  <rule ipv="ipv4" table="nat" chain="KUMA_INBOUND" priority="3">-p tcp --dport 15008 -j RETURN</rule>
+  <rule ipv="ipv4" table="nat" chain="PREROUTING" priority="3">-p tcp -j KUMA_INBOUND</rule>
+  <rule ipv="ipv4" table="nat" chain="KUMA_INBOUND" priority="3">-p tcp --dport 22 -j RETURN</rule>
+  <rule ipv="ipv4" table="nat" chain="OUTPUT" priority="3">-p tcp -j KUMA_OUTPUT</rule>
+  <rule ipv="ipv4" table="nat" chain="KUMA_OUTPUT" priority="3">-d 127.0.0.1/32 -j RETURN</rule>
+</direct>

--- a/firewalld/testdata/no_duplicates_direct.golden.xml
+++ b/firewalld/testdata/no_duplicates_direct.golden.xml
@@ -2,10 +2,6 @@
 <direct>
   <chain ipv="ipv4" table="nat" chain="KUMA_INBOUND"></chain>
   <chain ipv="ipv4" table="nat" chain="KUMA_OUTPUT"></chain>
-  <rule ipv="ipv4" table="raw" chain="PREROUTING" priority="3">-p udp --sport 53 -j CT --zone 1</rule>
-  <rule ipv="ipv4" table="raw" chain="OUTPUT" priority="3">-p udp --dport 53 -m owner --uid-owner 5678 -j CT --zone 1</rule>
-  <rule ipv="ipv4" table="raw" chain="OUTPUT" priority="3">-p udp --sport 15053 -m owner --uid-owner 5678 -j CT --zone 2</rule>
-  <rule ipv="ipv4" table="raw" chain="OUTPUT" priority="3">-p udp --dport 53 -j CT --zone 2</rule>
   <rule ipv="ipv4" table="nat" chain="KUMA_INBOUND" priority="3">-p tcp --dport 15008 -j RETURN</rule>
   <rule ipv="ipv4" table="nat" chain="PREROUTING" priority="3">-p tcp -j KUMA_INBOUND</rule>
   <rule ipv="ipv4" table="nat" chain="KUMA_INBOUND" priority="3">-p tcp --dport 22 -j RETURN</rule>

--- a/firewalld/testdata/no_duplicates_direct.input.txt
+++ b/firewalld/testdata/no_duplicates_direct.input.txt
@@ -1,0 +1,23 @@
+* raw
+-A PREROUTING -p udp --sport 53 -j CT --zone 1
+-A OUTPUT -p udp --dport 53 -m owner --uid-owner 5678 -j CT --zone 1
+-A OUTPUT -p udp --sport 15053 -m owner --uid-owner 5678 -j CT --zone 2
+-A OUTPUT -p udp --sport 15053 -m owner --uid-owner 5678 -j CT --zone 2
+-A OUTPUT -p udp --sport 15053 -m owner --uid-owner 5678 -j CT --zone 2
+-A OUTPUT -p udp --dport 53 -j CT --zone 2
+COMMIT
+* nat
+-N KUMA_INBOUND
+-N KUMA_OUTPUT
+-A KUMA_INBOUND -p tcp --dport 15008 -j RETURN
+-A PREROUTING -p tcp -j KUMA_INBOUND
+-A KUMA_INBOUND -p tcp --dport 22 -j RETURN
+-A KUMA_INBOUND -p tcp --dport 22 -j RETURN
+-A KUMA_INBOUND -p tcp --dport 22 -j RETURN
+-A OUTPUT -p tcp -j KUMA_OUTPUT
+-A KUMA_OUTPUT -d 127.0.0.1/32 -j RETURN
+-A OUTPUT -p tcp -j KUMA_OUTPUT
+-A KUMA_OUTPUT -d 127.0.0.1/32 -j RETURN
+-N KUMA_OUTPUT
+-N KUMA_INBOUND
+COMMIT

--- a/firewalld/testdata/no_duplicates_direct.input.txt
+++ b/firewalld/testdata/no_duplicates_direct.input.txt
@@ -1,11 +1,3 @@
-* raw
--A PREROUTING -p udp --sport 53 -j CT --zone 1
--A OUTPUT -p udp --dport 53 -m owner --uid-owner 5678 -j CT --zone 1
--A OUTPUT -p udp --sport 15053 -m owner --uid-owner 5678 -j CT --zone 2
--A OUTPUT -p udp --sport 15053 -m owner --uid-owner 5678 -j CT --zone 2
--A OUTPUT -p udp --sport 15053 -m owner --uid-owner 5678 -j CT --zone 2
--A OUTPUT -p udp --dport 53 -j CT --zone 2
-COMMIT
 * nat
 -N KUMA_INBOUND
 -N KUMA_OUTPUT

--- a/firewalld/xml.go
+++ b/firewalld/xml.go
@@ -1,0 +1,113 @@
+package firewalld
+
+import (
+	"encoding/xml"
+	"reflect"
+)
+
+type Chain struct {
+	// required, ip family: "ipv4", "ipv6", "eb"
+	IPv string `xml:"ipv,attr"`
+
+	// required, netfilter table: "nat", "mangle", etc.
+	Table string `xml:"table,attr"`
+
+	// required, netfilter chain: "FORWARD", custom chain names
+	Chain string `xml:"chain,attr"`
+
+	XMLName struct{} `xml:"chain"`
+}
+
+func (c *Chain) String() string {
+	data, _ := xml.MarshalIndent(c, "", "  ")
+
+	return string(data)
+}
+
+func NewIP4Chain(table, chain string) *Chain {
+	c := &Chain{
+		IPv:   "ipv4",
+		Table: table,
+		Chain: chain,
+	}
+
+	return c
+}
+
+type Rule struct {
+	// required, ip family: "ipv4", "ipv6", "eb"
+	IPv string `xml:"ipv,attr"`
+
+	// required, netfilter table: "nat", "mangle", etc.
+	Table string `xml:"table,attr"`
+
+	// required, netfilter chain: "FORWARD", custom chain names
+	Chain string `xml:"chain,attr"`
+
+	// required, smaller the number more front the rule in chain
+	Priority int `xml:"priority,attr"`
+
+	// match and action command line options for {ip,ip6,eb}tables
+	Body string `xml:",chardata"`
+
+	XMLName struct{} `xml:"rule"`
+}
+
+func (r *Rule) String() string {
+	data, _ := xml.MarshalIndent(r, "", "  ")
+
+	return string(data)
+}
+
+func NewIP4Rule(table string, priority int, chain, body string) *Rule {
+	return &Rule{
+		Priority: priority,
+		IPv:      "ipv4",
+		Table:    table,
+		Chain:    chain,
+		Body:     body,
+	}
+}
+
+type Direct struct {
+	Chains []*Chain
+	Rules  []*Rule
+
+	XMLName struct{} `xml:"direct"`
+}
+
+func (d *Direct) Bytes() []byte {
+	data, _ := xml.MarshalIndent(d, "", "  ")
+
+	return append([]byte(xml.Header), data...)
+}
+
+func (d *Direct) String() string {
+	return string(d.Bytes())
+}
+
+func (d *Direct) AddChain(chain *Chain) {
+	for _, c := range d.Chains {
+		if reflect.DeepEqual(c, chain) {
+			return
+		}
+	}
+
+	d.Chains = append(d.Chains, chain)
+}
+
+func (d *Direct) AddRule(rule *Rule) {
+	for _, r := range d.Rules {
+		if reflect.DeepEqual(r, rule) {
+			return
+		}
+	}
+
+	d.Rules = append(d.Rules, rule)
+}
+
+func NewDirect(rules ...*Rule) *Direct {
+	return &Direct{
+		Rules: rules,
+	}
+}

--- a/test/framework/golden/update_files.go
+++ b/test/framework/golden/update_files.go
@@ -1,0 +1,12 @@
+package golden
+
+import (
+	"os"
+)
+
+func UpdateGoldenFiles() bool {
+	return os.Getenv("UPDATE_GOLDEN_FILES") == "true"
+}
+
+const RerunMsg = "Rerun the test with UPDATE_GOLDEN_FILES=true flag. Example: " +
+	"UPDATE_GOLDEN_FILES=true ginkgo"

--- a/test/framework/gomega_matchers/golden.go
+++ b/test/framework/gomega_matchers/golden.go
@@ -1,0 +1,114 @@
+package gomega_matchers
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+
+	"github.com/kumahq/kuma-net/test/framework/golden"
+)
+
+func MatchGoldenYAML(goldenFilePath ...string) types.GomegaMatcher {
+	return MatchGolden(gomega.MatchYAML, goldenFilePath...)
+}
+
+func MatchGoldenJSON(goldenFilePath ...string) types.GomegaMatcher {
+	return MatchGolden(gomega.MatchJSON, goldenFilePath...)
+}
+
+func MatchGoldenXML(goldenFilePath ...string) types.GomegaMatcher {
+	return MatchGolden(gomega.MatchXML, goldenFilePath...)
+}
+
+func MatchGoldenEqual(goldenFilePath ...string) types.GomegaMatcher {
+	return MatchGolden(func(expected interface{}) types.GomegaMatcher {
+		if expectedBytes, ok := expected.([]byte); ok {
+			expected = string(expectedBytes)
+		}
+
+		return gomega.Equal(expected)
+	}, goldenFilePath...)
+}
+
+type MatcherFn = func(expected interface{}) types.GomegaMatcher
+
+// MatchGolden matches Golden file overriding it with actual content
+// if UPDATE_GOLDEN_FILES is set to true
+func MatchGolden(
+	matcherFn MatcherFn,
+	goldenFilePath ...string,
+) types.GomegaMatcher {
+	return &GoldenMatcher{
+		MatcherFactory: matcherFn,
+		GoldenFilePath: filepath.Join(goldenFilePath...),
+	}
+}
+
+type GoldenMatcher struct {
+	MatcherFactory MatcherFn
+	Matcher        types.GomegaMatcher
+	GoldenFilePath string
+}
+
+var _ types.GomegaMatcher = &GoldenMatcher{}
+
+func (g *GoldenMatcher) Match(actual interface{}) (success bool, err error) {
+	actualContent, err := g.actualString(actual)
+	if err != nil {
+		return false, err
+	}
+
+	if golden.UpdateGoldenFiles() {
+		if len(actualContent) > 0 && actualContent[len(actualContent)-1] != '\n' {
+			actualContent += "\n"
+		}
+
+		if err := os.WriteFile(g.GoldenFilePath, []byte(actualContent), 0644); err != nil {
+			return false, fmt.Errorf("could not update golden file: %s", err)
+		}
+	}
+
+	expected, err := os.ReadFile(g.GoldenFilePath)
+	if err != nil {
+		return false, fmt.Errorf("could not read golden file: %s", err)
+	}
+
+	// Generate a new instance of the matcher for this match. Since
+	// the matcher might keep internal state, we want to keep the same
+	// instance for subsequent message calls.
+	g.Matcher = g.MatcherFactory(expected)
+
+	return g.Matcher.Match(actualContent)
+}
+
+func (g *GoldenMatcher) FailureMessage(actual interface{}) (message string) {
+	actualContent, err := g.actualString(actual)
+	if err != nil {
+		return err.Error()
+	}
+
+	return golden.RerunMsg + "\n\n" + g.Matcher.FailureMessage(actualContent)
+}
+
+func (g *GoldenMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	actualContent, err := g.actualString(actual)
+	if err != nil {
+		return err.Error()
+	}
+
+	return g.Matcher.NegatedFailureMessage(actualContent)
+}
+
+func (g *GoldenMatcher) actualString(actual interface{}) (string, error) {
+	switch actual := actual.(type) {
+	case []byte:
+		return string(actual), nil
+	case string:
+		return actual, nil
+	default:
+		return "", fmt.Errorf("not supported type %T for MatchGolden", actual)
+	}
+}


### PR DESCRIPTION
Move firewalld related logic from `kumahq/kuma` to
`kumahq/kuma-net`.

As we are supporting longer - verbose commands and flags, I had to
modify a little bit existing firewalld logic as well as update
tests, which made it more error proof and robust.

Updated CI to run firewalld tests

ref. https://github.com/kumahq/kuma-net/issues/54 (will close the issue when changes in `kumahq/kuma` will be merged)

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits): 👍 

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?: 👍 
