### PR TITLE
feat(*): added ability to include only specific ports in tp rules

### DIFF
--- a/iptables/config/config.go
+++ b/iptables/config/config.go
@@ -18,6 +18,7 @@ type TrafficFlow struct {
 	Chain         Chain
 	RedirectChain Chain
 	ExcludePorts  []uint16
+	IncludePorts  []uint16
 }
 
 type DNS struct {
@@ -108,12 +109,14 @@ func defaultConfig() Config {
 				Chain:         Chain{Name: "MESH_INBOUND"},
 				RedirectChain: Chain{Name: "MESH_INBOUND_REDIRECT"},
 				ExcludePorts:  []uint16{},
+				IncludePorts:  []uint16{},
 			},
 			Outbound: TrafficFlow{
 				Port:          15001,
 				Chain:         Chain{Name: "MESH_OUTBOUND"},
 				RedirectChain: Chain{Name: "MESH_OUTBOUND_REDIRECT"},
 				ExcludePorts:  []uint16{},
+				IncludePorts:  []uint16{},
 			},
 			DNS: DNS{Port: 15053, Enabled: false, ConntrackZoneSplit: true},
 		},
@@ -158,6 +161,10 @@ func MergeConfigWithDefaults(cfg Config) Config {
 		result.Redirect.Inbound.ExcludePorts = cfg.Redirect.Inbound.ExcludePorts
 	}
 
+	if len(cfg.Redirect.Inbound.IncludePorts) > 0 {
+		result.Redirect.Inbound.IncludePorts = cfg.Redirect.Inbound.IncludePorts
+	}
+
 	// .Redirect.Outbound
 	if cfg.Redirect.Outbound.Port != 0 {
 		result.Redirect.Outbound.Port = cfg.Redirect.Outbound.Port
@@ -173,6 +180,10 @@ func MergeConfigWithDefaults(cfg Config) Config {
 
 	if len(cfg.Redirect.Outbound.ExcludePorts) > 0 {
 		result.Redirect.Outbound.ExcludePorts = cfg.Redirect.Outbound.ExcludePorts
+	}
+
+	if len(cfg.Redirect.Outbound.IncludePorts) > 0 {
+		result.Redirect.Outbound.IncludePorts = cfg.Redirect.Outbound.IncludePorts
 	}
 
 	// .Redirect.DNS

--- a/test/blackbox_tests/inbound_redirect_test.go
+++ b/test/blackbox_tests/inbound_redirect_test.go
@@ -328,3 +328,178 @@ var _ = Describe("Inbound IPv6 TCP traffic from any ports except excluded ones",
 		}(),
 	)
 })
+
+var _ = Describe("Inbound IPv4 TCP traffic only from included ports", func() {
+	var err error
+	var ns *netns.NetNS
+
+	BeforeEach(func() {
+		ns, err = netns.NewNetNSBuilder().Build()
+		Expect(err).To(BeNil())
+	})
+
+	AfterEach(func() {
+		Expect(ns.Cleanup()).To(Succeed())
+	})
+
+	DescribeTable("should be redirected to the inbound_redirection port",
+		func(serverPort, randomPort, includedPort uint16) {
+			// given
+			tproxyConfig := config.Config{
+				Redirect: config.Redirect{
+					Inbound: config.TrafficFlow{
+						Port:         serverPort,
+						IncludePorts: []uint16{includedPort},
+						ExcludePorts: []uint16{includedPort},
+					},
+				},
+				RuntimeOutput: ioutil.Discard,
+			}
+			peerAddress := ns.Veth().PeerAddress()
+
+			redirectReadyC, redirectErrC := tcp.UnsafeStartTCPServer(
+				ns,
+				fmt.Sprintf(":%d", serverPort),
+				tcp.ReplyWithOriginalDstIPv4,
+				tcp.CloseConn,
+			)
+			Eventually(redirectReadyC).Should(BeClosed())
+			Consistently(redirectErrC).ShouldNot(Receive())
+
+			randomReadyC, randomErrC := tcp.UnsafeStartTCPServer(
+				ns,
+				fmt.Sprintf(":%d", randomPort),
+				tcp.ReplyWith("foobar"),
+				tcp.CloseConn,
+			)
+			Eventually(randomReadyC).Should(BeClosed())
+			Consistently(randomErrC).ShouldNot(Receive())
+
+			// when
+			Eventually(ns.UnsafeExec(func() {
+				Expect(builder.RestoreIPTables(tproxyConfig)).Error().To(Succeed())
+			})).Should(BeClosed())
+
+			// then
+			Expect(tcp.DialIPWithPortAndGetReply(peerAddress, includedPort)).
+				To(Equal(fmt.Sprintf("%s:%d", peerAddress, includedPort)))
+
+			// then
+			Expect(tcp.DialIPWithPortAndGetReply(peerAddress, randomPort)).
+				To(Equal("foobar"))
+
+			// then
+			Eventually(redirectErrC).Should(BeClosed())
+			Eventually(randomErrC).Should(BeClosed())
+		},
+		func() []TableEntry {
+			var entries []TableEntry
+			var lockedPorts []uint16
+
+			for i := 0; i < blackbox_tests.TestCasesAmount; i++ {
+				randomPorts := socket.GenerateRandomPortsSlice(3, lockedPorts...)
+				// This gives us more entropy as all generated ports will be
+				// different from each other
+				lockedPorts = append(lockedPorts, randomPorts...)
+				desc := fmt.Sprintf("to port %%d, from port %%d (included: %%d)")
+				entry := Entry(
+					EntryDescription(desc),
+					randomPorts[0],
+					randomPorts[1],
+					randomPorts[2],
+				)
+				entries = append(entries, entry)
+			}
+
+			return entries
+		}(),
+	)
+})
+
+var _ = Describe("Inbound IPv6 TCP traffic only from included ports", func() {
+	var err error
+	var ns *netns.NetNS
+
+	BeforeEach(func() {
+		ns, err = netns.NewNetNSBuilder().WithIPv6(true).Build()
+		Expect(err).To(BeNil())
+	})
+
+	AfterEach(func() {
+		Expect(ns.Cleanup()).To(Succeed())
+	})
+
+	DescribeTable("should be redirected to the inbound_redirection port",
+		func(serverPort, randomPort, includedPort uint16) {
+			// given
+			tproxyConfig := config.Config{
+				Redirect: config.Redirect{
+					Inbound: config.TrafficFlow{
+						PortIPv6:     serverPort,
+						IncludePorts: []uint16{includedPort},
+						ExcludePorts: []uint16{includedPort},
+					},
+				},
+				IPv6:          true,
+				RuntimeOutput: ioutil.Discard,
+			}
+			peerAddress := ns.Veth().PeerAddress()
+
+			redirectReadyC, redirectErrC := tcp.UnsafeStartTCPServer(
+				ns,
+				fmt.Sprintf(":%d", serverPort),
+				tcp.ReplyWithOriginalDstIPv6,
+				tcp.CloseConn,
+			)
+			Eventually(redirectReadyC).Should(BeClosed())
+			Consistently(redirectErrC).ShouldNot(Receive())
+
+			randomReadyC, randomErrC := tcp.UnsafeStartTCPServer(
+				ns,
+				fmt.Sprintf(":%d", randomPort),
+				tcp.ReplyWith("foobar"),
+				tcp.CloseConn,
+			)
+			Eventually(randomReadyC).Should(BeClosed())
+			Consistently(randomErrC).ShouldNot(Receive())
+
+			// when
+			Eventually(ns.UnsafeExec(func() {
+				Expect(builder.RestoreIPTables(tproxyConfig)).Error().To(Succeed())
+			})).Should(BeClosed())
+
+			// then
+			Expect(tcp.DialIPWithPortAndGetReply(peerAddress, includedPort)).
+				To(Equal(fmt.Sprintf("[%s]:%d", peerAddress, includedPort)))
+
+			// then
+			Expect(tcp.DialIPWithPortAndGetReply(peerAddress, randomPort)).
+				To(Equal("foobar"))
+
+			// then
+			Eventually(redirectErrC).Should(BeClosed())
+			Eventually(randomErrC).Should(BeClosed())
+		},
+		func() []TableEntry {
+			var entries []TableEntry
+			var lockedPorts []uint16
+
+			for i := 0; i < blackbox_tests.TestCasesAmount; i++ {
+				randomPorts := socket.GenerateRandomPortsSlice(3, lockedPorts...)
+				// This gives us more entropy as all generated ports will be
+				// different from each other
+				lockedPorts = append(lockedPorts, randomPorts...)
+				desc := fmt.Sprintf("to port %%d, from port %%d (excluded: %%d)")
+				entry := Entry(
+					EntryDescription(desc),
+					randomPorts[0],
+					randomPorts[1],
+					randomPorts[2],
+				)
+				entries = append(entries, entry)
+			}
+
+			return entries
+		}(),
+	)
+})


### PR DESCRIPTION
Added option to configure ports that are redirected by `iptables` and only them.

Fix #30 
