### PR TITLE
feat: add logic to use ebpf for tproxy

### DIFF
--- a/ebpf/ebpf.go
+++ b/ebpf/ebpf.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package ebpf
 
 import (
@@ -139,23 +141,19 @@ func isDirEmpty(dirPath string) (bool, error) {
 		return false, err
 	}
 
-	var isEmpty []bool
 	for _, entry := range dir {
 		if !entry.IsDir() {
 			return false, nil
 		}
 
-		e, err := isDirEmpty(path.Join(dirPath, entry.Name()))
-		if err != nil {
-			return false, err
-		}
+		fullPath := path.Join(dirPath, entry.Name())
 
-		if !e {
-			isEmpty = append(isEmpty, e)
+		if isEmpty, err := isDirEmpty(fullPath); err != nil || !isEmpty {
+			return false, err
 		}
 	}
 
-	return len(isEmpty) == 0, nil
+	return true, nil
 }
 
 func InitBPFFSMaybe(fsPath string) error {

--- a/ebpf/ebpf.go
+++ b/ebpf/ebpf.go
@@ -1,0 +1,191 @@
+package ebpf
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/kumahq/kuma-net/transparent-proxy/config"
+)
+
+// MaxItemLen is the maximal amount of items like ports or IP ranges to include
+// or/and exclude. It's currently hardcoded to 10 as merbridge during creation
+// of this map is assigning hardcoded 244 bytes for map values:
+//
+//  Cidr:        8 bytes
+//    Cidr.Net:  4 bytes
+//    Cidr.Mask: 1 byte
+//    pad:       3 bytes
+//
+//  PodConfig:                                  244 bytes
+//    PodConfig.StatusPort:                       2 bytes
+//    pad:                                        2 bytes
+//    PodConfig.ExcludeOutRanges (10x Cidr):     80 bytes
+//    PodConfig.IncludeOutRanges (10x Cidr):     80 bytes
+//    PodConfig.IncludeInPorts   (10x 2 bytes):  20 bytes
+//    PodConfig.IncludeOutPorts  (10x 2 bytes):  20 bytes
+//    PodConfig.ExcludeInPorts   (10x 2 bytes):  20 bytes
+//    PodConfig.ExcludeOutPorts  (10x 2 bytes):  20 bytes
+//
+// todo (bartsmykla): merbridge flagged this constant to be changed, so if
+//                    it will be changed, we have to update it
+const MaxItemLen = 10
+
+// LocalPodIPSPinnedMapPathRelativeToBPFFS is a path where the local_pod_ips map
+// is pinned, it's hardcoded as "{BPFFS_path}/tc/globals/local_pod_ips" because
+// merbridge is hard-coding it as well, and we don't want to allot to change it
+// by mistake
+const LocalPodIPSPinnedMapPathRelativeToBPFFS = "/tc/globals/local_pod_ips"
+
+type Cidr struct {
+	Net  uint32 // network order
+	Mask uint8
+	_    [3]uint8 // pad
+}
+
+type PodConfig struct {
+	StatusPort       uint16
+	_                uint16 // pad
+	ExcludeOutRanges [MaxItemLen]Cidr
+	IncludeOutRanges [MaxItemLen]Cidr
+	IncludeInPorts   [MaxItemLen]uint16
+	IncludeOutPorts  [MaxItemLen]uint16
+	ExcludeInPorts   [MaxItemLen]uint16
+	ExcludeOutPorts  [MaxItemLen]uint16
+}
+
+func IpStrToUint32(ipstr string) (uint32, error) {
+	ip := net.ParseIP(ipstr)
+	if ip == nil {
+		return 0, fmt.Errorf("error when parsing ip string: %s", ipstr)
+	}
+
+	return *(*uint32)(unsafe.Pointer(&ip[12])), nil
+}
+
+func run(cmdToExec string, args, envVars []string, stdout, stderr io.Writer) error {
+	_, _ = stdout.Write([]byte(fmt.Sprintf("Running: %s %s %s\n", strings.Join(envVars, " "), cmdToExec, strings.Join(args, " "))))
+
+	cmd := exec.Command(cmdToExec, args...)
+	cmd.Env = append(os.Environ(), envVars...)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+
+	err := cmd.Run()
+	if code := cmd.ProcessState.ExitCode(); code != 0 || err != nil {
+		return fmt.Errorf("unexpected exit code: %d, err: %v", code, err)
+	}
+
+	_, _ = stdout.Write([]byte("\n"))
+
+	return nil
+}
+
+func runMake(target string, cfg config.Config) error {
+	args := []string{"--directory", cfg.Ebpf.ProgramsSourcePath, target}
+	envVars := []string{
+		"MESH_MODE=kuma",
+		"USE_RECONNECT=1",
+		"DEBUG=1",
+		"PROG_MOUNT_PATH=" + cfg.Ebpf.BPFFSPath,
+	}
+
+	return run("make", args, envVars, cfg.RuntimeStdout, cfg.RuntimeStderr)
+}
+
+type Program struct {
+	PinName          string
+	MakeLoadTarget   string
+	MakeAttachTarget string
+}
+
+func LoadAndAttachEbpfPrograms(programs []*Program, cfg config.Config) error {
+	var errs []string
+
+	for _, p := range programs {
+		if _, err := os.Stat(path.Join(cfg.Ebpf.BPFFSPath, p.PinName)); err != nil {
+			if os.IsNotExist(err) {
+				if err := runMake(p.MakeLoadTarget, cfg); err != nil {
+					errs = append(errs, err.Error())
+					continue
+				}
+
+				if err := runMake(p.MakeAttachTarget, cfg); err != nil {
+					errs = append(errs, err.Error())
+				}
+			} else {
+				errs = append(errs, err.Error())
+			}
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("loading and attaching ebpf programs failed:\n\t%s", strings.Join(errs, "\n\t"))
+	}
+
+	return nil
+}
+
+func isDirEmpty(dirPath string) (bool, error) {
+	dir, err := os.ReadDir(dirPath)
+	if err != nil {
+		return false, err
+	}
+
+	var isEmpty []bool
+	for _, entry := range dir {
+		if !entry.IsDir() {
+			return false, nil
+		}
+
+		e, err := isDirEmpty(path.Join(dirPath, entry.Name()))
+		if err != nil {
+			return false, err
+		}
+
+		if !e {
+			isEmpty = append(isEmpty, e)
+		}
+	}
+
+	return len(isEmpty) == 0, nil
+}
+
+func InitBPFFSMaybe(fsPath string) error {
+	stat, err := os.Stat(fsPath)
+	if err != nil {
+		return err
+	}
+
+	if !stat.IsDir() {
+		return fmt.Errorf("bpf fs path (%s) is not a directory", fsPath)
+	}
+
+	isEmpty, err := isDirEmpty(fsPath)
+	if err != nil {
+		return fmt.Errorf("checking if BPF file system path is empty failed: %v", err)
+	}
+
+	// if directory is not empty, we are assuming BPF filesystem was already
+	// initialized, so we won't do it again
+	if !isEmpty {
+		return nil
+	}
+
+	if err := unix.Mount("bpf", fsPath, "bpf", 0, ""); err != nil {
+		return fmt.Errorf("mounting BPF file system failed: %v", err)
+	}
+
+	if err := os.MkdirAll(path.Join(fsPath, "tc", "globals"), 0750); err != nil {
+		return fmt.Errorf("making directory for tc globals pinning failed: %v", err)
+	}
+
+	return nil
+}

--- a/ebpf/setup.go
+++ b/ebpf/setup.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package ebpf
 
 import (

--- a/ebpf/setup.go
+++ b/ebpf/setup.go
@@ -1,0 +1,119 @@
+package ebpf
+
+import (
+	"fmt"
+	"os"
+
+	ciliumebpf "github.com/cilium/ebpf"
+
+	"github.com/kumahq/kuma-net/transparent-proxy/config"
+)
+
+var programs = []*Program{
+	{
+		PinName:          "connect",
+		MakeLoadTarget:   "load-connect",
+		MakeAttachTarget: "attach-connect",
+	},
+	{
+		PinName:          "sockops",
+		MakeLoadTarget:   "load-sockops",
+		MakeAttachTarget: "attach-sockops",
+	},
+	{
+		PinName:          "get_sockopts",
+		MakeLoadTarget:   "load-getsock",
+		MakeAttachTarget: "attach-getsock",
+	},
+	{
+		PinName:          "redir",
+		MakeLoadTarget:   "load-redir",
+		MakeAttachTarget: "attach-redir",
+	},
+	{
+		PinName:          "sendmsg",
+		MakeLoadTarget:   "load-sendmsg",
+		MakeAttachTarget: "attach-sendmsg",
+	},
+	{
+		PinName:          "recvmsg",
+		MakeLoadTarget:   "load-recvmsg",
+		MakeAttachTarget: "attach-recvmsg",
+	},
+}
+
+func Setup(cfg config.Config) (string, error) {
+	if os.Getuid() != 0 {
+		return "", fmt.Errorf("root user in required for this process or container")
+	}
+
+	if err := InitBPFFSMaybe(cfg.Ebpf.BPFFSPath); err != nil {
+		return "", fmt.Errorf("initializing BPF file system failed: %v", err)
+	}
+
+	if err := LoadAndAttachEbpfPrograms(programs, cfg); err != nil {
+		return "", err
+	}
+
+	localPodIPsMap, err := ciliumebpf.LoadPinnedMap(
+		cfg.Ebpf.BPFFSPath+LocalPodIPSPinnedMapPathRelativeToBPFFS,
+		&ciliumebpf.LoadPinOptions{},
+	)
+	if err != nil {
+		return "", fmt.Errorf("loading pinned local_pod_ips map failed: %v", err)
+	}
+
+	instanceIP := os.Getenv(cfg.Ebpf.InstanceIPEnvVarName)
+
+	ip, err := IpStrToUint32(instanceIP)
+	if err != nil {
+		return "", err
+	}
+
+	// exclude inbound ports
+
+	excludeInboundPorts := [MaxItemLen]uint16{
+		cfg.Redirect.Inbound.Port,
+		cfg.Redirect.Inbound.PortIPv6,
+		cfg.Redirect.Outbound.Port,
+	}
+
+	allowedAmountOfExcludeInPorts := MaxItemLen - len(excludeInboundPorts)
+
+	if len(cfg.Redirect.Inbound.ExcludePorts) > allowedAmountOfExcludeInPorts {
+		return "", fmt.Errorf(
+			"maximal allowed amound of exclude inbound ports (%d) exceeded (%d): %+v",
+			allowedAmountOfExcludeInPorts,
+			len(cfg.Redirect.Inbound.ExcludePorts),
+			cfg.Redirect.Inbound.ExcludePorts,
+		)
+	}
+
+	// exclude outbound ports
+
+	excludeOutPorts := [MaxItemLen]uint16{}
+
+	if len(cfg.Redirect.Outbound.ExcludePorts) > MaxItemLen {
+		return "", fmt.Errorf(
+			"maximal allowed amound of exclude outbound ports (%d) exceeded (%d): %+v",
+			MaxItemLen,
+			len(cfg.Redirect.Outbound.ExcludePorts),
+			cfg.Redirect.Outbound.ExcludePorts,
+		)
+	}
+
+	if err := localPodIPsMap.Update(ip, &PodConfig{
+		ExcludeInPorts:  excludeInboundPorts,
+		ExcludeOutPorts: excludeOutPorts,
+	}, ciliumebpf.UpdateAny); err != nil {
+		return "", fmt.Errorf(
+			"updating pinned local_pod_ips map with current instance IP (%s) failed: %v",
+			instanceIP,
+			err,
+		)
+	}
+
+	_, _ = cfg.RuntimeStdout.Write([]byte(fmt.Sprintf("local_pod_ips map was updated with current instance IP: %s\n\n", instanceIP)))
+
+	return "", nil
+}

--- a/ebpf/setup.go
+++ b/ebpf/setup.go
@@ -67,7 +67,7 @@ func Setup(cfg config.Config) (string, error) {
 
 	instanceIP := os.Getenv(cfg.Ebpf.InstanceIPEnvVarName)
 
-	ip, err := IpStrToUint32(instanceIP)
+	ip, err := ipStrToUint32(instanceIP)
 	if err != nil {
 		return "", err
 	}

--- a/ebpf/setup_fallback.go
+++ b/ebpf/setup_fallback.go
@@ -1,0 +1,13 @@
+//go:build !linux
+
+package ebpf
+
+import (
+	"fmt"
+
+	"github.com/kumahq/kuma-net/transparent-proxy/config"
+)
+
+func Setup(config.Config) (string, error) {
+	return "", fmt.Errorf("ebpf is currently supported only on linux")
+}

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 )
 
 require (
+	github.com/cilium/ebpf v0.9.1 // indirect
 	github.com/miekg/dns v1.1.50 // indirect
 	golang.org/x/mod v0.4.2 // indirect
 	golang.org/x/tools v0.1.6-0.20210726203631-07bc1bf47fb2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
+github.com/cilium/ebpf v0.9.1 h1:64sn2K3UKw8NbP/blsixRpF3nXuyhz/VjRlRzvlBRu4=
+github.com/cilium/ebpf v0.9.1/go.mod h1:+OhNOIXx/Fnu1IE8bJz2dzOA+VSfyTfdNUVdlQnxUFY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=

--- a/iptables/builder/builder_mangle.go
+++ b/iptables/builder/builder_mangle.go
@@ -1,10 +1,10 @@
 package builder
 
 import (
-	"github.com/kumahq/kuma-net/iptables/config"
 	. "github.com/kumahq/kuma-net/iptables/parameters"
 	. "github.com/kumahq/kuma-net/iptables/parameters/match/conntrack"
 	"github.com/kumahq/kuma-net/iptables/table"
+	"github.com/kumahq/kuma-net/transparent-proxy/config"
 )
 
 func buildMangleTable(cfg config.Config) *table.MangleTable {

--- a/iptables/builder/builder_nat.go
+++ b/iptables/builder/builder_nat.go
@@ -2,10 +2,10 @@ package builder
 
 import (
 	. "github.com/kumahq/kuma-net/iptables/chain"
-	"github.com/kumahq/kuma-net/iptables/config"
 	. "github.com/kumahq/kuma-net/iptables/consts"
 	. "github.com/kumahq/kuma-net/iptables/parameters"
 	"github.com/kumahq/kuma-net/iptables/table"
+	"github.com/kumahq/kuma-net/transparent-proxy/config"
 )
 
 func buildMeshInbound(cfg config.TrafficFlow, prefix string, meshInboundRedirect string) *Chain {

--- a/iptables/builder/builder_raw.go
+++ b/iptables/builder/builder_raw.go
@@ -1,10 +1,10 @@
 package builder
 
 import (
-	"github.com/kumahq/kuma-net/iptables/config"
 	. "github.com/kumahq/kuma-net/iptables/consts"
 	. "github.com/kumahq/kuma-net/iptables/parameters"
 	"github.com/kumahq/kuma-net/iptables/table"
+	"github.com/kumahq/kuma-net/transparent-proxy/config"
 )
 
 func buildRawTable(

--- a/iptables/setup.go
+++ b/iptables/setup.go
@@ -1,0 +1,26 @@
+package iptables
+
+import (
+	"github.com/kumahq/kuma-net/iptables/builder"
+	"github.com/kumahq/kuma-net/transparent-proxy/config"
+)
+
+func Setup(cfg config.Config) (string, error) {
+	if cfg.DryRun {
+		// TODO (bartsmykla): we should generate IPv4 and IPv6 when cfg.IPv6 is
+		//  set, but currently in DryRun mode we would just display IPv6
+		//  configuration when cfg.IPv6 is set
+		// TODO (bartsmykla): I think dns servers should be provided as a config
+		//  value instead of explicit function parameter here
+		output, err := builder.BuildIPTables(cfg, nil, cfg.IPv6)
+		if err != nil {
+			return "", err
+		}
+
+		_, _ = cfg.RuntimeStdout.Write([]byte(output))
+
+		return output, nil
+	}
+
+	return builder.RestoreIPTables(cfg)
+}

--- a/test/blackbox_tests/dns_test.go
+++ b/test/blackbox_tests/dns_test.go
@@ -12,7 +12,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/kumahq/kuma-net/iptables/builder"
-	"github.com/kumahq/kuma-net/iptables/config"
 	"github.com/kumahq/kuma-net/iptables/consts"
 	"github.com/kumahq/kuma-net/test/blackbox_tests"
 	"github.com/kumahq/kuma-net/test/framework/netns"
@@ -21,6 +20,7 @@ import (
 	"github.com/kumahq/kuma-net/test/framework/sysctl"
 	"github.com/kumahq/kuma-net/test/framework/tcp"
 	"github.com/kumahq/kuma-net/test/framework/udp"
+	"github.com/kumahq/kuma-net/transparent-proxy/config"
 )
 
 var _ = Describe("Outbound IPv4 DNS/UDP traffic to port 53", func() {
@@ -54,7 +54,7 @@ var _ = Describe("Outbound IPv4 DNS/UDP traffic to port 53", func() {
 						Enabled: true,
 					},
 				},
-				RuntimeOutput: ioutil.Discard,
+				RuntimeStdout: ioutil.Discard,
 			}
 			serverAddress := fmt.Sprintf("%s:%d", consts.LocalhostIPv4, randomPort)
 
@@ -127,7 +127,7 @@ var _ = Describe("Outbound IPv4 DNS/TCP traffic to port 53", func() {
 						Enabled: true,
 					},
 				},
-				RuntimeOutput: ioutil.Discard,
+				RuntimeStdout: ioutil.Discard,
 			}
 			serverAddress := fmt.Sprintf("%s:%d", consts.LocalhostIPv4, dnsPort)
 
@@ -214,7 +214,7 @@ var _ = Describe("Outbound IPv6 DNS/UDP traffic to port 53", func() {
 					},
 				},
 				IPv6:          true,
-				RuntimeOutput: ioutil.Discard,
+				RuntimeStdout: ioutil.Discard,
 			}
 			serverAddress := fmt.Sprintf("%s:%d", consts.LocalhostIPv6, randomPort)
 
@@ -288,7 +288,7 @@ var _ = Describe("Outbound IPv6 DNS/TCP traffic to port 53", func() {
 					},
 				},
 				IPv6:          true,
-				RuntimeOutput: ioutil.Discard,
+				RuntimeStdout: ioutil.Discard,
 			}
 			serverAddress := fmt.Sprintf("%s:%d", consts.LocalhostIPv6, dnsPort)
 
@@ -380,7 +380,7 @@ var _ = Describe("Outbound IPv4 DNS/UDP conntrack zone splitting", func() {
 					},
 				},
 				Owner:         config.Owner{UID: strconv.Itoa(int(uid))},
-				RuntimeOutput: ioutil.Discard,
+				RuntimeStdout: ioutil.Discard,
 			}
 			want := map[string]uint{
 				s1Address: blackbox_tests.DNSConntrackZoneSplittingStressCallsAmount,
@@ -497,7 +497,7 @@ var _ = Describe("Outbound IPv6 DNS/UDP conntrack zone splitting", func() {
 				},
 				IPv6:          true,
 				Owner:         config.Owner{UID: strconv.Itoa(int(uid))},
-				RuntimeOutput: ioutil.Discard,
+				RuntimeStdout: ioutil.Discard,
 			}
 			want := map[string]uint{
 				s1Address: blackbox_tests.DNSConntrackZoneSplittingStressCallsAmount,
@@ -601,7 +601,7 @@ var _ = Describe("Outbound IPv4 DNS/UDP traffic to port 53 only for addresses in
 						ResolvConfigPath: "testdata/resolv4.conf",
 					},
 				},
-				RuntimeOutput: ioutil.Discard,
+				RuntimeStdout: ioutil.Discard,
 			}
 			serverAddress := fmt.Sprintf("%s:%d", consts.LocalhostIPv4, randomPort)
 
@@ -676,7 +676,7 @@ var _ = Describe("Outbound IPv6 DNS/UDP traffic to port 53 only for addresses in
 						ResolvConfigPath: "testdata/resolv6.conf",
 					},
 				},
-				RuntimeOutput: ioutil.Discard,
+				RuntimeStdout: ioutil.Discard,
 				IPv6:          true,
 			}
 			serverAddress := fmt.Sprintf("%s:%d", consts.LocalhostIPv6, randomPort)
@@ -759,7 +759,7 @@ var _ = Describe("Outbound IPv4 DNS/UDP conntrack zone splitting with specific I
 					},
 				},
 				Owner:         config.Owner{UID: strconv.Itoa(int(uid))},
-				RuntimeOutput: ioutil.Discard,
+				RuntimeStdout: ioutil.Discard,
 			}
 			want := map[string]uint{
 				s1Address: blackbox_tests.DNSConntrackZoneSplittingStressCallsAmount,

--- a/test/blackbox_tests/inbound_redirect_test.go
+++ b/test/blackbox_tests/inbound_redirect_test.go
@@ -8,11 +8,11 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/kumahq/kuma-net/iptables/builder"
-	"github.com/kumahq/kuma-net/iptables/config"
 	"github.com/kumahq/kuma-net/test/blackbox_tests"
 	"github.com/kumahq/kuma-net/test/framework/netns"
 	"github.com/kumahq/kuma-net/test/framework/socket"
 	"github.com/kumahq/kuma-net/test/framework/tcp"
+	"github.com/kumahq/kuma-net/transparent-proxy/config"
 )
 
 var _ = Describe("Inbound IPv4 TCP traffic from any ports", func() {
@@ -43,7 +43,7 @@ var _ = Describe("Inbound IPv4 TCP traffic from any ports", func() {
 						Enabled: true,
 					},
 				},
-				RuntimeOutput: ioutil.Discard,
+				RuntimeStdout: ioutil.Discard,
 			}
 
 			tcpReadyC, tcpErrC := tcp.UnsafeStartTCPServer(
@@ -119,7 +119,7 @@ var _ = Describe("Inbound IPv6 TCP traffic from any ports", func() {
 					},
 				},
 				IPv6:          true,
-				RuntimeOutput: ioutil.Discard,
+				RuntimeStdout: ioutil.Discard,
 			}
 
 			tcpReadyC, tcpErrC := tcp.UnsafeStartTCPServer(
@@ -193,7 +193,7 @@ var _ = Describe("Inbound IPv4 TCP traffic from any ports except excluded ones",
 						Enabled: true,
 					},
 				},
-				RuntimeOutput: ioutil.Discard,
+				RuntimeStdout: ioutil.Discard,
 			}
 			peerAddress := ns.Veth().PeerAddress()
 
@@ -283,7 +283,7 @@ var _ = Describe("Inbound IPv6 TCP traffic from any ports except excluded ones",
 					},
 				},
 				IPv6:          true,
-				RuntimeOutput: ioutil.Discard,
+				RuntimeStdout: ioutil.Discard,
 			}
 			peerAddress := ns.Veth().PeerAddress()
 
@@ -373,7 +373,7 @@ var _ = Describe("Inbound IPv4 TCP traffic only from included ports", func() {
 						Enabled: true,
 					},
 				},
-				RuntimeOutput: ioutil.Discard,
+				RuntimeStdout: ioutil.Discard,
 			}
 			peerAddress := ns.Veth().PeerAddress()
 
@@ -465,7 +465,7 @@ var _ = Describe("Inbound IPv6 TCP traffic only from included ports", func() {
 					},
 				},
 				IPv6:          true,
-				RuntimeOutput: ioutil.Discard,
+				RuntimeStdout: ioutil.Discard,
 			}
 			peerAddress := ns.Veth().PeerAddress()
 
@@ -556,7 +556,7 @@ var _ = Describe("Inbound IPv4 TCP traffic from any ports", func() {
 						Enabled: true,
 					},
 				},
-				RuntimeOutput: ioutil.Discard,
+				RuntimeStdout: ioutil.Discard,
 			}
 
 			tcpReadyC, tcpErrC := tcp.UnsafeStartTCPServer(
@@ -632,7 +632,7 @@ var _ = Describe("Inbound IPv6 TCP traffic from any ports", func() {
 					},
 				},
 				IPv6:          true,
-				RuntimeOutput: ioutil.Discard,
+				RuntimeStdout: ioutil.Discard,
 			}
 
 			tcpReadyC, tcpErrC := tcp.UnsafeStartTCPServer(

--- a/test/blackbox_tests/outbound_redirect_test.go
+++ b/test/blackbox_tests/outbound_redirect_test.go
@@ -9,13 +9,13 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/kumahq/kuma-net/iptables/builder"
-	"github.com/kumahq/kuma-net/iptables/config"
 	"github.com/kumahq/kuma-net/iptables/consts"
 	"github.com/kumahq/kuma-net/test/blackbox_tests"
 	"github.com/kumahq/kuma-net/test/framework/ip"
 	"github.com/kumahq/kuma-net/test/framework/netns"
 	"github.com/kumahq/kuma-net/test/framework/socket"
 	"github.com/kumahq/kuma-net/test/framework/tcp"
+	"github.com/kumahq/kuma-net/transparent-proxy/config"
 )
 
 var _ = Describe("Outbound IPv4 TCP traffic to any address:port", func() {
@@ -45,7 +45,7 @@ var _ = Describe("Outbound IPv4 TCP traffic to any address:port", func() {
 						Port:    serverPort,
 					},
 				},
-				RuntimeOutput: ioutil.Discard,
+				RuntimeStdout: ioutil.Discard,
 			}
 
 			tcpReadyC, tcpErrC := tcp.UnsafeStartTCPServer(
@@ -124,7 +124,7 @@ var _ = Describe("Outbound IPv6 TCP traffic to any address:port", func() {
 					},
 				},
 				IPv6:          true,
-				RuntimeOutput: ioutil.Discard,
+				RuntimeStdout: ioutil.Discard,
 			}
 
 			tcpReadyC, tcpErrC := tcp.UnsafeStartTCPServer(
@@ -203,7 +203,7 @@ var _ = Describe("Outbound IPv4 TCP traffic to any address:port except excluded 
 						Enabled: true,
 					},
 				},
-				RuntimeOutput: ioutil.Discard,
+				RuntimeStdout: ioutil.Discard,
 			}
 
 			tcpReadyC, tcpErrC := tcp.UnsafeStartTCPServer(
@@ -299,7 +299,7 @@ var _ = Describe("Outbound IPv6 TCP traffic to any address:port except excluded 
 					},
 				},
 				IPv6:          true,
-				RuntimeOutput: ioutil.Discard,
+				RuntimeStdout: ioutil.Discard,
 			}
 
 			tcpReadyC, tcpErrC := tcp.UnsafeStartTCPServer(
@@ -396,7 +396,7 @@ var _ = Describe("Outbound IPv4 TCP traffic only to included port", func() {
 						Enabled: true,
 					},
 				},
-				RuntimeOutput: ioutil.Discard,
+				RuntimeStdout: ioutil.Discard,
 			}
 
 			tcpReadyC, tcpErrC := tcp.UnsafeStartTCPServer(
@@ -493,7 +493,7 @@ var _ = Describe("Outbound IPv6 TCP traffic only to included port", func() {
 					},
 				},
 				IPv6:          true,
-				RuntimeOutput: ioutil.Discard,
+				RuntimeStdout: ioutil.Discard,
 			}
 
 			tcpReadyC, tcpErrC := tcp.UnsafeStartTCPServer(
@@ -588,7 +588,7 @@ var _ = Describe("Outbound IPv4 TCP traffic to any address:port", func() {
 						Enabled: true,
 					},
 				},
-				RuntimeOutput: ioutil.Discard,
+				RuntimeStdout: ioutil.Discard,
 			}
 
 			tcpReadyC, tcpErrC := tcp.UnsafeStartTCPServer(
@@ -665,7 +665,7 @@ var _ = Describe("Outbound IPv6 TCP traffic to any address:port", func() {
 					},
 				},
 				IPv6:          true,
-				RuntimeOutput: ioutil.Discard,
+				RuntimeStdout: ioutil.Discard,
 			}
 
 			tcpReadyC, tcpErrC := tcp.UnsafeStartTCPServer(

--- a/transparent-proxy/config/config.go
+++ b/transparent-proxy/config/config.go
@@ -46,20 +46,34 @@ func (c Chain) GetFullName(prefix string) string {
 	return prefix + c.Name
 }
 
+type Ebpf struct {
+	Enabled              bool
+	InstanceIPEnvVarName string
+	BPFFSPath            string
+	ProgramsSourcePath   string
+}
+
 type Config struct {
 	Owner    Owner
 	Redirect Redirect
+	Ebpf     Ebpf
 	// DropInvalidPackets when set will enable configuration which should drop
 	// packets in invalid states
 	DropInvalidPackets bool
 	// IPv6 when set will be used to configure iptables as well as ip6tables
 	IPv6 bool
-	// RuntimeOutput is the place where Any debugging, runtime information
+	// RuntimeStdout is the place where Any debugging, runtime information
 	// will be placed (os.Stdout by default)
-	RuntimeOutput io.Writer
+	RuntimeStdout io.Writer
+	// RuntimeStderr is the place where error, runtime information will be
+	// placed (os.Stderr by default)
+	RuntimeStderr io.Writer
 	// Verbose when set will generate iptables configuration with longer
 	// argument/flag names, additional comments etc.
 	Verbose bool
+	// DryRun when set will not execute, but just display instructions which
+	// otherwise would have served to install transparent proxy
+	DryRun bool
 }
 
 // ShouldDropInvalidPackets is just a convenience function which can be used in
@@ -96,7 +110,7 @@ func (c Config) ShouldConntrackZoneSplit() bool {
 	// instead of failing the whole iptables application, we can log the warning,
 	// skip conntrack related rules and move forward
 	if err := exec.Command("iptables", "-m", "conntrack", "--help").Run(); err != nil {
-		_, _ = fmt.Fprintf(c.RuntimeOutput,
+		_, _ = fmt.Fprintf(c.RuntimeStdout,
 			"[WARNING] error occured when validating if 'conntrack' iptables "+
 				"module is present. Rules for DNS conntrack zone "+
 				"splitting won't be applied: %s\n", err,
@@ -138,10 +152,18 @@ func defaultConfig() Config {
 				ResolvConfigPath:   "/etc/resolv.conf",
 			},
 		},
+		Ebpf: Ebpf{
+			Enabled:              false,
+			InstanceIPEnvVarName: "INSTANCE_IP",
+			BPFFSPath:            "/run/kuma/bpf",
+			ProgramsSourcePath:   "/kuma/ebpf",
+		},
 		DropInvalidPackets: false,
 		IPv6:               false,
-		RuntimeOutput:      os.Stdout,
+		RuntimeStdout:      os.Stdout,
+		RuntimeStderr:      os.Stderr,
 		Verbose:            true,
+		DryRun:             false,
 	}
 }
 
@@ -218,19 +240,41 @@ func MergeConfigWithDefaults(cfg Config) Config {
 		result.Redirect.DNS.Port = cfg.Redirect.DNS.Port
 	}
 
+	// .Ebpf
+	result.Ebpf.Enabled = cfg.Ebpf.Enabled
+	if cfg.Ebpf.InstanceIPEnvVarName != "" {
+		result.Ebpf.InstanceIPEnvVarName = cfg.Ebpf.InstanceIPEnvVarName
+	}
+
+	if cfg.Ebpf.BPFFSPath != "" {
+		result.Ebpf.BPFFSPath = cfg.Ebpf.BPFFSPath
+	}
+
+	if cfg.Ebpf.ProgramsSourcePath != "" {
+		result.Ebpf.ProgramsSourcePath = cfg.Ebpf.ProgramsSourcePath
+	}
+
 	// .DropInvalidPackets
 	result.DropInvalidPackets = cfg.DropInvalidPackets
 
 	// .IPv6
 	result.IPv6 = cfg.IPv6
 
-	// .RuntimeOutput
-	if cfg.RuntimeOutput != nil {
-		result.RuntimeOutput = cfg.RuntimeOutput
+	// .RuntimeStdout
+	if cfg.RuntimeStdout != nil {
+		result.RuntimeStdout = cfg.RuntimeStdout
+	}
+
+	// .RuntimeStderr
+	if cfg.RuntimeStderr != nil {
+		result.RuntimeStderr = cfg.RuntimeStderr
 	}
 
 	// .Verbose
 	result.Verbose = cfg.Verbose
+
+	// .DryRun
+	result.DryRun = cfg.DryRun
 
 	return result
 }

--- a/transparent-proxy/setup.go
+++ b/transparent-proxy/setup.go
@@ -1,0 +1,15 @@
+package transparent_proxy
+
+import (
+	"github.com/kumahq/kuma-net/ebpf"
+	"github.com/kumahq/kuma-net/iptables"
+	"github.com/kumahq/kuma-net/transparent-proxy/config"
+)
+
+func Setup(cfg config.Config) (string, error) {
+	if cfg.Ebpf.Enabled {
+		return ebpf.Setup(cfg)
+	}
+
+	return iptables.Setup(cfg)
+}


### PR DESCRIPTION
- Added code which allows to use ebpf instead of iptables
  to configure transparent proxy
- Added ebpf related configuration fields to our config struct
- Created another abstraction which allows to wrap iptables and
  ebpf "configurators", which allows to remove some code from
  the kuma repository responsible for generation of iptables
  rules. Now this wrapper is available under `transparent-proxy`
  directory, and depending on configuration, it will call ebpf
  or iptables respectively
- Moved from kuma codebase some logs displayed when installing
  transparent proxy using iptables, which allows us to have
  greater control of what's being logged and when
- Moved out configuration from iptables directory to more
  appropriate place (created earlier `transparent-proxy` directory)
  as now we have the possibility to use it for ebpf as well as
  for iptables
- Added `DryRun` option to configuration, as now we are controlling
  what is being logged inside this repository instead of kuma
- Added `RuntimeStderr` option to configuration, which is used for
  ebpf, when executing some commands (withoult it, we wouldn't
  be able to control where error logs would go during `os.Exec`)
- Renamed `RuntimeOutput` configuration option to `RuntimeStdout`
  to be consistent with just added `RuntimeStderr` option

As a followup PR I will add ebpf to our blackbox tests

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits): 👍 

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?: 👍 
