### PR TITLE
feat: introduce ebpf tc programs

### DIFF
--- a/ebpf/setup.go
+++ b/ebpf/setup.go
@@ -65,6 +65,14 @@ func Setup(cfg config.Config) (string, error) {
 		return "", fmt.Errorf("loading pinned local_pod_ips map failed: %v", err)
 	}
 
+	tcEbpfObj := fmt.Sprintf("%s/mb_tc.o", cfg.Ebpf.ProgramsSourcePath)
+
+	if iface, err := getNonLoopbackInterface(); err != nil {
+		return "", fmt.Errorf("getting non-loopback interface failed: %v", err)
+	} else if err := AttachTC(iface.Name, tcEbpfObj); err != nil {
+		return "", fmt.Errorf("attaching tc failed: %v", err)
+	}
+
 	ip, err := ipStrToUint32(cfg.Ebpf.InstanceIP)
 	if err != nil {
 		return "", err

--- a/ebpf/tc.go
+++ b/ebpf/tc.go
@@ -1,0 +1,133 @@
+//go:build linux
+
+package ebpf
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os/exec"
+	"strings"
+)
+
+// TODO (bartsmykla): check if it's possible to replace execs of "sh -c tc [...]"
+//  with some more idiomatic approach (maybe https://github.com/florianl/go-tc ?)
+
+const clsact = "clsact"
+
+// helper struct to parse "tc -json qdisc show [...]` results
+type tcQdisc struct {
+	Kind string `json:"kind"`
+}
+
+// TODO (bartsmykla): create common abstraction with run function from ebpf.go
+func runTc(args ...string) (bytes.Buffer, error) {
+	cmdWithArgs := append([]string{"tc"}, args...)
+	tcCmd := strings.Join(cmdWithArgs, " ")
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	cmd := exec.Command("sh", "-c", tcCmd)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return stdout, fmt.Errorf("executing %q failed with error: %q (stderr: %s)",
+			tcCmd, err, strings.TrimSpace(stderr.String()))
+	}
+
+	return stdout, nil
+}
+
+func isQdiscPresent(qdisc, dev string) (bool, error) {
+	var qdiscs []tcQdisc
+
+	stdout, err := runTc("-json", "qdisc", "show", "dev", dev)
+	if err != nil {
+		return false, err
+	}
+
+	if err := json.NewDecoder(&stdout).Decode(&qdiscs); err != nil {
+		return false, fmt.Errorf("json decoding failed: %v", err)
+	}
+
+	for _, tcQdisc := range qdiscs {
+		if tcQdisc.Kind == qdisc {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// TODO (bartsmykla): currently we are assuming there is only one other than
+//  loopback interface, and we are attaching eBPF programs only to it.
+//  It's probably fine in the context of k8s and init containers,
+//  but not for vms/universal
+func getNonLoopbackInterface() (*net.Interface, error) {
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list network interfaces: %v", err)
+	}
+
+	for _, iface := range interfaces {
+		if iface.Flags&net.FlagLoopback == 0 {
+			return &iface, nil
+		}
+	}
+
+	return nil, fmt.Errorf("cannot find other than loopback interface")
+}
+
+// AttachTC will attach tc-related eBPF programs
+func AttachTC(dev, obj string) error {
+	hasClsact, err := isQdiscPresent(clsact, dev)
+	if err != nil {
+		return fmt.Errorf("checking if %q qdisc is already present failed: %v", clsact, err)
+	}
+
+	if !hasClsact {
+		if _, err := runTc("qdisc", "add", "dev", dev, clsact); err != nil {
+			return fmt.Errorf("adding %s qdisc to %s failed: %q", clsact, dev, err)
+		}
+	}
+
+	if _, err := runTc("filter", "add", "prio", "66", "dev", dev, "ingress",
+		"bpf", "da", "obj", obj, "sec", "classifier_ingress"); err != nil {
+		return fmt.Errorf("failed to attach tc(ingress) to %s: %v", dev, err)
+	}
+
+	if _, err := runTc("filter", "add", "prio", "66", "dev", dev, "egress",
+		"bpf", "da", "obj", obj, "sec", "classifier_egress"); err != nil {
+		return fmt.Errorf("failed to attach tc(egress) to %s: %v", dev, err)
+	}
+
+	return nil
+}
+
+func CleanUpTC(dev string) error {
+	hasClsact, err := isQdiscPresent(clsact, dev)
+	if err != nil {
+		return fmt.Errorf("checking if %q qdisc is already present failed: %v", clsact, err)
+	}
+
+	if hasClsact {
+		if _, err := runTc("qdisc", "delete", "dev", dev, clsact); err != nil {
+			return fmt.Errorf("failed to delete %s qdisc from %s: %v", clsact, dev, err)
+		}
+
+		return nil
+	}
+
+	if _, err := runTc("filter", "delete", "dev", dev, "egress", "prio", "66"); err != nil {
+		return fmt.Errorf("failed to delete egress filter from %s: %v", dev, err)
+	}
+
+	if _, err := runTc("filter", "delete", "dev", dev, "ingress", "prio", "66"); err != nil {
+		return fmt.Errorf("failed to delete ingress filter from %s: %v", dev, err)
+	}
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/kumahq/kuma-net
 go 1.18
 
 require (
+	github.com/cilium/ebpf v0.9.1
+	github.com/miekg/dns v1.1.50
 	github.com/onsi/ginkgo/v2 v2.1.3
 	github.com/onsi/gomega v1.19.0
 	github.com/vishvananda/netlink v1.2.1-beta.2
@@ -11,14 +13,11 @@ require (
 require (
 	github.com/vishvananda/netns v0.0.0-20211101163701-50045581ed74
 	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
-	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
+	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a
 	golang.org/x/text v0.3.7 // indirect
 )
 
 require (
-	github.com/cilium/ebpf v0.9.1 // indirect
-	github.com/go-errors/errors v1.4.2 // indirect
-	github.com/miekg/dns v1.1.50 // indirect
 	golang.org/x/mod v0.4.2 // indirect
 	golang.org/x/tools v0.1.6-0.20210726203631-07bc1bf47fb2 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,8 @@ golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e h1:fLOSk5Q00efkSvAm+4xcoXD+RRmLmmulPn5I3Y9F2EM=
-golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
+golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=


### PR DESCRIPTION
The introduced by this changes logic allows kuma to attach tc ebpf programs in init containers which solves a tone of problems (mtls bypassing, not working virtual probles, not being able to exclude ports via annotations and more)

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits): 👍 

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?: 👍 
