### PR TITLE
feat(*): added logging rule to the iptables

### DIFF
--- a/iptables/builder/builder_nat.go
+++ b/iptables/builder/builder_nat.go
@@ -191,6 +191,11 @@ func addOutputRules(cfg config.Config, dnsServers []string, nat *table.NatTable)
 	outboundChainName := cfg.Redirect.Outbound.Chain.GetFullName(cfg.Redirect.NamePrefix)
 	dnsRedirectPort := cfg.Redirect.DNS.Port
 	uid := cfg.Owner.UID
+	if cfg.Log.Enabled {
+		nat.Output().Append(
+			Jump(Log(OutputLogPrefix, cfg.Log.Level)),
+		)
+	}
 
 	// Excluded outbound ports for UIDs
 	for _, uIDsToPorts := range cfg.Redirect.Outbound.ExcludePortsForUIDs {
@@ -252,6 +257,11 @@ func buildNatTable(
 	inboundChainName := cfg.Redirect.Inbound.Chain.GetFullName(prefix)
 	nat := table.Nat()
 
+	if cfg.Log.Enabled {
+		nat.Prerouting().Append(
+			Jump(Log(PreroutingLogPrefix, cfg.Log.Level)),
+		)
+	}
 	nat.Prerouting().Append(
 		Protocol(Tcp()),
 		Jump(ToUserDefinedChain(inboundChainName)),

--- a/iptables/consts/consts.go
+++ b/iptables/consts/consts.go
@@ -15,6 +15,8 @@ const (
 	// TODO (bartsmykla): add some description
 	InboundPassthroughSourceAddressCIDRIPv4 = "127.0.0.6/32"
 	InboundPassthroughSourceAddressCIDRIPv6 = "::6/128"
+	OutputLogPrefix                         = "OUTPUT:"
+	PreroutingLogPrefix                     = "PREROUTING:"
 	UDP                                     = "udp"
 	TCP                                     = "tcp"
 )

--- a/iptables/parameters/jump.go
+++ b/iptables/parameters/jump.go
@@ -44,3 +44,13 @@ func Return() *JumpParameter {
 func Drop() *JumpParameter {
 	return &JumpParameter{parameters: []string{"DROP"}}
 }
+
+func Log(prefix string, level uint16) *JumpParameter {
+	return &JumpParameter{
+		parameters: []string{
+			"LOG",
+			"--log-prefix", prefix,
+			"--log-level", strconv.Itoa(int(level)),
+		},
+	}
+}

--- a/test/blackbox_tests/inbound_redirect_test.go
+++ b/test/blackbox_tests/inbound_redirect_test.go
@@ -44,6 +44,9 @@ var _ = Describe("Inbound IPv4 TCP traffic from any ports", func() {
 					},
 				},
 				RuntimeStdout: ioutil.Discard,
+				Log: config.LogConfig{
+					Enabled: true,
+				},
 			}
 
 			tcpReadyC, tcpErrC := tcp.UnsafeStartTCPServer(
@@ -120,6 +123,9 @@ var _ = Describe("Inbound IPv6 TCP traffic from any ports", func() {
 				},
 				IPv6:          true,
 				RuntimeStdout: ioutil.Discard,
+				Log: config.LogConfig{
+					Enabled: true,
+				},
 			}
 
 			tcpReadyC, tcpErrC := tcp.UnsafeStartTCPServer(

--- a/test/blackbox_tests/outbound_redirect_test.go
+++ b/test/blackbox_tests/outbound_redirect_test.go
@@ -2,6 +2,10 @@ package blackbox_tests_test
 
 import (
 	"fmt"
+	"io/ioutil"
+	"net"
+	"strconv"
+
 	"github.com/kumahq/kuma-net/iptables/builder"
 	"github.com/kumahq/kuma-net/iptables/consts"
 	"github.com/kumahq/kuma-net/test/blackbox_tests"
@@ -14,9 +18,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/vishvananda/netlink"
-	"io/ioutil"
-	"net"
-	"strconv"
 )
 
 var _ = Describe("Outbound IPv4 TCP traffic to any address:port", func() {
@@ -217,6 +218,9 @@ var _ = Describe("Outbound IPv4 TCP traffic to any address:port except excluded 
 					},
 				},
 				RuntimeStdout: ioutil.Discard,
+				Log: config.LogConfig{
+					Enabled: true,
+				},
 			}
 
 			tcpReadyC, tcpErrC := tcp.UnsafeStartTCPServer(
@@ -437,6 +441,9 @@ var _ = Describe("Outbound IPv6 TCP traffic to any address:port except excluded 
 				},
 				IPv6:          true,
 				RuntimeStdout: ioutil.Discard,
+				Log: config.LogConfig{
+					Enabled: true,
+				},
 			}
 
 			tcpReadyC, tcpErrC := tcp.UnsafeStartTCPServer(

--- a/transparent-proxy/config/config.go
+++ b/transparent-proxy/config/config.go
@@ -7,6 +7,8 @@ import (
 	"os/exec"
 )
 
+const DebugLogLevel uint16 = 7
+
 type Owner struct {
 	UID string
 }
@@ -67,6 +69,11 @@ type Ebpf struct {
 	ProgramsSourcePath string
 }
 
+type LogConfig struct {
+	Enabled bool
+	Level   uint16
+}
+
 type Config struct {
 	Owner    Owner
 	Redirect Redirect
@@ -88,6 +95,9 @@ type Config struct {
 	// DryRun when set will not execute, but just display instructions which
 	// otherwise would have served to install transparent proxy
 	DryRun bool
+	// Log is the place where configuration for logging iptables rules will
+	// be placed
+	Log LogConfig
 }
 
 // ShouldDropInvalidPackets is just a convenience function which can be used in
@@ -177,6 +187,10 @@ func defaultConfig() Config {
 		RuntimeStderr:      os.Stderr,
 		Verbose:            true,
 		DryRun:             false,
+		Log: LogConfig{
+			Enabled: false,
+			Level:   DebugLogLevel,
+		},
 	}
 }
 
@@ -292,6 +306,12 @@ func MergeConfigWithDefaults(cfg Config) Config {
 
 	// .DryRun
 	result.DryRun = cfg.DryRun
+
+	// .Log
+	result.Log.Enabled = cfg.Log.Enabled
+	if result.Log.Level != DebugLogLevel {
+		result.Log.Level = cfg.Log.Level
+	}
 
 	return result
 }


### PR DESCRIPTION
Added the possibility to define iptables rules for logging. Because of https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=69b34fb996b2eee3970548cf6eb516d3ecb5eee  logging from a namespace is not available in system logs. I've added an option to enable iptables logs to a few tests to check if rules are not breaking applying of rules. Also, I didn't add an insert on the first place to not put them in front of the user rules.

Fix #31 