### PR TITLE
chore(ebpf): add cleanup fallback - non-linux arch

### DIFF
--- a/ebpf/cleanup_fallback.go
+++ b/ebpf/cleanup_fallback.go
@@ -1,0 +1,13 @@
+//go:build !linux
+
+package ebpf
+
+import (
+	"fmt"
+
+	"github.com/kumahq/kuma-net/transparent-proxy/config"
+)
+
+func Cleanup(config.Config) (string, error) {
+	return "", fmt.Errorf("ebpf is currently supported only on linux")
+}


### PR DESCRIPTION
It makes it consistent with `.Setup(...)` function and is necessary to not break CI in kuma

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits): 👍 

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?: 👍 
