### PR TITLE
chore(*): removed platform because buildx does it for us

### DIFF
--- a/tools/builds/dockerfiles/Dockerfile.kuma-net-ebpf
+++ b/tools/builds/dockerfiles/Dockerfile.kuma-net-ebpf
@@ -1,6 +1,4 @@
-ARG BASE_IMAGE_ARCH=amd64
-
-FROM --platform=linux/$BASE_IMAGE_ARCH ubuntu:22.04 as builder
+FROM ubuntu:22.04 as builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
`BASE_IMAGE_ARCH` was set to amd64 all the time. Removed it now buildx should provide the correct value.

ref #96 