### PR TITLE
fix(ebpf): removed net cleanup script which is not used anymore

### DIFF
--- a/ebpf/ebpf.go
+++ b/ebpf/ebpf.go
@@ -102,16 +102,6 @@ var programs = []*Program{
 		),
 	},
 	{
-		Name:  "mb_netns_cleanup",
-		Flags: flags(nil),
-		Cleanup: cleanPathsRelativeToBPFFS(
-			"netns_cleanup_prog",
-			"netns_cleanup_link",
-			MapRelativePathNetNSPodIPs,
-			MapRelativePathLocalPodIPs,
-		),
-	},
-	{
 		Name: "mb_tc",
 		Flags: func(
 			cfg config.Config,


### PR DESCRIPTION
After changes in https://github.com/kumahq/merbridge/pull/5 we do not need to cleanup map anymore