### PR TITLE
chore(ebpf): put ebpf programs in image to /ebpf/

### DIFF
--- a/tools/builds/dockerfiles/Dockerfile.kuma-net-ebpf
+++ b/tools/builds/dockerfiles/Dockerfile.kuma-net-ebpf
@@ -46,4 +46,4 @@ RUN rm -rf /app/bpf/mb_*.*
 FROM scratch
 
 COPY --from=builder /app/bpf/.output/bpftool/bpftool /
-COPY --from=builder /app/bpf/mb_* /bpf/
+COPY --from=builder /app/bpf/mb_* /ebpf/

--- a/tools/builds/dockerfiles/Dockerfile.kuma-net-ebpf
+++ b/tools/builds/dockerfiles/Dockerfile.kuma-net-ebpf
@@ -46,4 +46,4 @@ RUN rm -rf /app/bpf/mb_*.*
 FROM scratch
 
 COPY --from=builder /app/bpf/.output/bpftool/bpftool /
-COPY --from=builder /app/bpf/mb_* /
+COPY --from=builder /app/bpf/mb_* /bpf/


### PR DESCRIPTION
Put ebpf programs in docker image to `/ebpf/` directory instead of `/`

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits): 👍 

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?: 👍 
