### PR TITLE
fix(tp): insert docker vnet rules at the begining of PREROUTING chain

### DIFF
--- a/iptables/builder/builder_nat.go
+++ b/iptables/builder/builder_nat.go
@@ -263,7 +263,7 @@ func addPreroutingRules(cfg config.Config, nat *table.NatTable, ipv6 bool) error
 			// we accept only first : so in case of IPv6 there should be no problem with parsing
 			pair := strings.SplitN(cfg.Redirect.VNet.Networks[i], ":", 2)
 			if len(pair) < 2 {
-				return fmt.Errorf("incorrect definiton of virtual network: %s", cfg.Redirect.VNet.Networks[i])
+				return fmt.Errorf("incorrect definition of virtual network: %s", cfg.Redirect.VNet.Networks[i])
 			}
 			ipAddress, _, err := net.ParseCIDR(pair[1])
 			if err != nil {

--- a/iptables/builder/builder_nat.go
+++ b/iptables/builder/builder_nat.go
@@ -250,7 +250,7 @@ func addOutputRules(cfg config.Config, dnsServers []string, nat *table.NatTable)
 
 func addPreroutingRules(cfg config.Config, nat *table.NatTable, ipv6 bool) error {
 	inboundChainName := cfg.Redirect.Inbound.Chain.GetFullName(cfg.Redirect.NamePrefix)
-	var rulePosition = 1
+	rulePosition := 1
 	if cfg.Log.Enabled {
 		nat.Prerouting().Append(
 			Jump(Log(PreroutingLogPrefix, cfg.Log.Level)),

--- a/iptables/builder/builder_nat_test.go
+++ b/iptables/builder/builder_nat_test.go
@@ -1,0 +1,151 @@
+package builder
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kumahq/kuma-net/iptables/table"
+	"github.com/kumahq/kuma-net/transparent-proxy/config"
+)
+
+var _ = Describe("Builder nat", func() {
+	DescribeTable("should insert PREROUTING rules",
+		func(vnet []string, verbose bool, ipv6 bool, expect ...string) {
+			// given
+			nat := table.Nat()
+			cfg := config.Config{
+				Redirect: config.Redirect{
+					Inbound: config.TrafficFlow{
+						Enabled: true,
+						Port:    1234,
+						Chain:   config.Chain{Name: "MESH_INBOUND"},
+					},
+					Outbound: config.TrafficFlow{
+						Enabled: true,
+						Port:    12345,
+						Chain:   config.Chain{Name: "MESH_OUTBOUND"},
+					},
+					DNS: config.DNS{Port: 15053},
+					VNet: config.VNet{
+						Networks: vnet,
+					},
+				},
+			}
+
+			// when
+			addPreroutingRules(cfg, nat, ipv6)
+			table := nat.Build(verbose)
+
+			// then
+			for _, rule := range expect {
+				Expect(table).To(ContainSubstring(rule))
+			}
+
+		},
+		Entry("ipv4 not verbose",
+			[]string{"docker:1.2.3.4/24", "br+:127.0.0.0/32"},
+			false,
+			false,
+			// rules have random order so we cannot compare addresses and names
+			"-I PREROUTING 1",
+			"-i docker -m udp -p udp --dport 53 -j REDIRECT --to-ports 15053",
+			"-I PREROUTING 2",
+			"! -d 1.2.3.4/24 -i docker -p tcp -j REDIRECT --to-ports 12345",
+			"-I PREROUTING 3",
+			"-i br+ -m udp -p udp --dport 53 -j REDIRECT --to-ports 15053",
+			"-I PREROUTING 4",
+			"! -d 127.0.0.0/32 -i br+ -p tcp -j REDIRECT --to-ports 12345",
+			"-I PREROUTING 5 -p tcp -j MESH_INBOUND",
+		),
+		Entry("ipv4 not verbose",
+			[]string{"docker:1.2.3.4/24", "br+:127.0.0.0/32"},
+			true,
+			false,
+			"--insert PREROUTING 1",
+			"--in-interface docker --match udp --protocol udp --destination-port 53 --jump REDIRECT --to-ports 15053",
+			"--insert PREROUTING 2",
+			"! --destination 1.2.3.4/24 --in-interface docker --protocol tcp --jump REDIRECT --to-ports 12345",
+			"--insert PREROUTING 3",
+			"--in-interface br+ --match udp --protocol udp --destination-port 53 --jump REDIRECT --to-ports 15053",
+			"--insert PREROUTING 4",
+			"! --destination 127.0.0.0/32 --in-interface br+ --protocol tcp --jump REDIRECT --to-ports 12345",
+			"--insert PREROUTING 5 --protocol tcp --jump MESH_INBOUND",
+		),
+		Entry("ipv6 not verbose",
+			[]string{"docker:::6/24", "br+:1::1/128"},
+			false,
+			true,
+			"-I PREROUTING 1",
+			"-i docker -m udp -p udp --dport 53 -j REDIRECT --to-ports 15053",
+			"-I PREROUTING 2",
+			"! -d ::6/24 -i docker -p tcp -j REDIRECT --to-ports 12345",
+			"-I PREROUTING 3",
+			"-i br+ -m udp -p udp --dport 53 -j REDIRECT --to-ports 15053",
+			"-I PREROUTING 4",
+			"! -d 1::1/128 -i br+ -p tcp -j REDIRECT --to-ports 12345",
+			"-I PREROUTING 5 -p tcp -j MESH_INBOUND",
+		),
+		Entry("ipv6 not verbose",
+			[]string{"docker:::6/24", "br+:1::1/128"},
+			true,
+			true,
+			"--insert PREROUTING 1",
+			"--in-interface docker --match udp --protocol udp --destination-port 53 --jump REDIRECT --to-ports 15053",
+			"--insert PREROUTING 2",
+			"! --destination ::6/24 --in-interface docker --protocol tcp --jump REDIRECT --to-ports 12345",
+			"--insert PREROUTING 3",
+			"--in-interface br+ --match udp --protocol udp --destination-port 53 --jump REDIRECT --to-ports 15053",
+			"--insert PREROUTING 4",
+			"! --destination 1::1/128 --in-interface br+ --protocol tcp --jump REDIRECT --to-ports 12345",
+			"--insert PREROUTING 5 --protocol tcp --jump MESH_INBOUND",
+		),
+		Entry("ipv4 without ipv6 rules",
+			[]string{"docker:127.0.0.6/24", "br+:1::1/128"},
+			true,
+			false,
+			"--insert PREROUTING 1 --in-interface docker --match udp --protocol udp --destination-port 53 --jump REDIRECT --to-ports 15053",
+			"--insert PREROUTING 2 ! --destination 127.0.0.6/24 --in-interface docker --protocol tcp --jump REDIRECT --to-ports 12345",
+			"--insert PREROUTING 3 --protocol tcp --jump MESH_INBOUND",
+		),
+		Entry("ipv6 without ipv4 rules",
+			[]string{"docker:127.0.0.6/24", "br+:1::1/128"},
+			true,
+			true,
+			"--insert PREROUTING 1 --in-interface br+ --match udp --protocol udp --destination-port 53 --jump REDIRECT --to-ports 15053",
+			"--insert PREROUTING 2 ! --destination 1::1/128 --in-interface br+ --protocol tcp --jump REDIRECT --to-ports 12345",
+			"--insert PREROUTING 3 --protocol tcp --jump MESH_INBOUND",
+		),
+	)
+
+	DescribeTable("should append PREROUTING rules",
+		func(verbose bool, ipv6 bool, expect ...string) {
+			// given
+			nat := table.Nat()
+			cfg := config.Config{
+				Redirect: config.Redirect{
+					Inbound: config.TrafficFlow{
+						Enabled: true,
+						Port:    1234,
+						Chain:   config.Chain{Name: "MESH_INBOUND"},
+					},
+					Outbound: config.TrafficFlow{
+						Enabled: true,
+						Port:    12345,
+						Chain:   config.Chain{Name: "MESH_OUTBOUND"},
+					},
+					DNS: config.DNS{Port: 15053},
+				},
+			}
+
+			// when
+			addPreroutingRules(cfg, nat, ipv6)
+			table := nat.Build(verbose)
+
+			// then
+			for _, rule := range expect {
+				Expect(table).To(ContainSubstring(rule))
+			}
+		},
+		Entry("ipv4 not verbose", false, false, "-A PREROUTING -p tcp -j MESH_INBOUND"),
+	)
+})

--- a/iptables/builder/builder_nat_test.go
+++ b/iptables/builder/builder_nat_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Builder nat", func() {
 			}
 
 			// when
-			addPreroutingRules(cfg, nat, ipv6)
+			Expect(addPreroutingRules(cfg, nat, ipv6)).ToNot(HaveOccurred())
 			table := nat.Build(verbose)
 
 			// then
@@ -138,7 +138,7 @@ var _ = Describe("Builder nat", func() {
 			}
 
 			// when
-			addPreroutingRules(cfg, nat, ipv6)
+			Expect(addPreroutingRules(cfg, nat, ipv6)).ToNot(HaveOccurred())
 			table := nat.Build(verbose)
 
 			// then

--- a/iptables/builder/builder_suite_test.go
+++ b/iptables/builder/builder_suite_test.go
@@ -1,0 +1,13 @@
+package builder_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func Test(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Iptables Builder Suite")
+}

--- a/iptables/chain/chain.go
+++ b/iptables/chain/chain.go
@@ -20,6 +20,12 @@ func (b *Chain) Append(parameters ...*Parameter) *Chain {
 	return b
 }
 
+func (b *Chain) Insert(position int, parameters ...*Parameter) *Chain {
+	b.commands = append(b.commands, commands.Insert(b.name, position, parameters))
+
+	return b
+}
+
 func (b *Chain) AppendIf(predicate func() bool, parameters ...*Parameter) *Chain {
 	if predicate() {
 		return b.Append(parameters...)

--- a/iptables/commands/command.go
+++ b/iptables/commands/command.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/kumahq/kuma-net/iptables/parameters"
@@ -10,6 +11,7 @@ type Command struct {
 	long       string
 	short      string
 	chainName  string
+	position   int
 	parameters []*parameters.Parameter
 }
 
@@ -26,6 +28,10 @@ func (c *Command) Build(verbose bool) string {
 		cmd = append(cmd, c.chainName)
 	}
 
+	if c.position != 0 {
+		cmd = append(cmd, strconv.Itoa(c.position))
+	}
+
 	for _, parameter := range c.parameters {
 		if parameter != nil {
 			cmd = append(cmd, parameter.Build(verbose))
@@ -39,7 +45,18 @@ func Append(chainName string, parameters []*parameters.Parameter) *Command {
 	return &Command{
 		long:       "--append",
 		short:      "-A",
+		position:   0,
 		chainName:  chainName,
+		parameters: parameters,
+	}
+}
+
+func Insert(chainName string, position int, parameters []*parameters.Parameter) *Command {
+	return &Command{
+		long:       "--insert",
+		short:      "-I",
+		chainName:  chainName,
+		position:   position,
 		parameters: parameters,
 	}
 }


### PR DESCRIPTION
Docker vnet rules need to be at the beginning of PREROUTING chain. Docker adds the rule which redirects all traffic and in case we won't insert them at the beginning traffic doesn't reach a sidecar.