### PR TITLE
ci(runner): use ubuntu-20.04

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -45,7 +45,7 @@ jobs:
         ginkgo run ./firewalld/...
 
   blackbox-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Hi @slonka,

I bet that the ubuntu-22.04 is causing the blackbox-tests failures

This might be related to [this Kuma Issue](https://github.com/kumahq/kuma/issues/5342)

Here are the different configurations for ubuntu-22.04 and ubuntu-20.04

[ubuntu-20.04](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md):

>Linux kernel version: 5.15.0-1023-azure


[ubuntu-22.04](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md):

>Linux kernel version: 5.15.0-1024-azure

Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>