### PR TITLE
fix(iptables): changed append to insert for dns

### DIFF
--- a/iptables/builder/builder_nat.go
+++ b/iptables/builder/builder_nat.go
@@ -238,7 +238,6 @@ func addOutputRules(cfg config.Config, dnsServers []string, nat *table.NatTable)
 				Protocol(Udp(DestinationPort(DNSPort))),
 				Jump(ToPort(dnsRedirectPort)),
 			)
-			rulePosition++
 		} else {
 			for _, dnsIp := range dnsServers {
 				nat.Output().Insert(

--- a/iptables/builder/builder_nat.go
+++ b/iptables/builder/builder_nat.go
@@ -215,7 +215,8 @@ func addOutputRules(cfg config.Config, dnsServers []string, nat *table.NatTable)
 			return fmt.Errorf("unknown protocol %s, only 'tcp' or 'udp' allowed", uIDsToPorts.Protocol)
 		}
 
-		nat.Output().Insert(rulePosition,
+		nat.Output().Insert(
+			rulePosition,
 			protocol,
 			Match(Owner(UidRangeOrValue(uIDsToPorts))),
 			Jump(Return()),


### PR DESCRIPTION
Because of order of iptables in docker, it might starts to fails if iptables rules are not the first one. Changed previous behaviour(append) to inserts.